### PR TITLE
Update octokit dependency to latest version

### DIFF
--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'rugged', '~> 0.19.0'
   s.add_dependency 'thor', '~> 0.18.0'
-  s.add_dependency 'octokit', '~> 2.6.0'
+  s.add_dependency 'octokit', '~> 2.7.1'
   s.add_dependency 'grit', '~> 2.5.0'
   s.add_development_dependency 'rake', '~> 10.1.0'
   s.add_development_dependency 'rspec', '~> 2.14.0'


### PR DESCRIPTION
This silences warnings stating `Faraday::Builder is now Faraday::RackBuilder`.
