### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Build Status](https://secure.travis-ci.org/mmozuras/pronto.png)](http://travis-ci.org/mmozuras/pronto)
 [![Gem Version](https://badge.fury.io/rb/pronto.png)](http://badge.fury.io/rb/pronto)
 [![Dependency Status](https://gemnasium.com/mmozuras/pronto.png)](https://gemnasium.com/mmozuras/pronto)
-[![Inline docs](http://inch-pages.github.io/github/mmozuras/pronto.png)](http://inch-pages.github.io/github/mmozuras/pronto)
+[![Inline docs](http://inch-ci.org/github/mmozuras/pronto.png)](http://inch-ci.org/github/mmozuras/pronto)
 
 Pronto runs analysis quickly by checking only the relevant changes. Created to
 be used on pull requests, but suited for other scenarios as well. Perfect if you


### PR DESCRIPTION
Hi Mindaugas,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/mmozuras/pronto.png)](http://inch-pages.github.io/github/mmozuras/pronto)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Pronto is http://inch-pages.github.io/github/mmozuras/pronto/

Inch Pages is still in it's infancy, but already used by projects like [Guard](https://github.com/guard/guard), [Haml](https://github.com/haml/haml), [Pry](https://github.com/pry/pry), and [Libnotify](https://github.com/splattael/libnotify).

What do you think?
