### PR TITLE
Updated rugged dependency to avoid flaky 0.21.0

### DIFF
--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.executables << 'pronto'
 
-  s.add_runtime_dependency 'rugged', '~> 0.19', '>= 0.19.0'
+  s.add_runtime_dependency 'rugged', '>= 0.19.0', '<= 0.20.0'
   s.add_runtime_dependency 'thor', '~> 0.19', '>= 0.19.1'
   s.add_runtime_dependency 'octokit', '~> 2.7', '>= 2.7.1'
   s.add_runtime_dependency 'grit', '~> 2.5', '>= 2.5.0'


### PR DESCRIPTION
0.19.0 compiles on OS X while 0.21.0 does not.
