### PR TITLE
Analyze changes in git index using "-i" option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New features
 
 * Try to detect pull request id automatically, if `PULL_REQUEST_ID` is not specified. Inspired by @willnet/prid.
+* [#40](https://github.com/mmozuras/pronto/issues/40): Add '--index' option for 'pronto run'. Pronto analyzes changes before committing.
 
 ## 0.3.3
 

--- a/lib/pronto/cli.rb
+++ b/lib/pronto/cli.rb
@@ -24,6 +24,11 @@ module Pronto
                   aliases: '-c',
                   banner: 'Commit for the diff'
 
+    method_option :index,
+                  type: :boolean,
+                  aliases: '-i',
+                  banner: 'Analyze changes in git index (staging area)'
+
     method_option :runner,
                   type: :array,
                   default: [],
@@ -43,7 +48,8 @@ module Pronto
       end
 
       formatter = ::Pronto::Formatter.get(options[:formatter])
-      messages = ::Pronto.run(options[:commit], '.', formatter)
+      commit = options[:index] ? :index : options[:commit]
+      messages = ::Pronto.run(commit, '.', formatter)
       exit(messages.count) if options[:'exit-code']
     rescue Rugged::RepositoryError
       puts '"pronto" should be run from a git repository'

--- a/lib/pronto/git/repository.rb
+++ b/lib/pronto/git/repository.rb
@@ -12,9 +12,14 @@ module Pronto
       end
 
       def diff(commit)
-        merge_base = merge_base(commit)
-        patches = @repo.diff(merge_base, head)
-        Patches.new(self, merge_base, patches)
+        if commit == :index
+          patches = @repo.index.diff
+          Patches.new(self, head, patches)
+        else
+          merge_base = merge_base(commit)
+          patches = @repo.diff(merge_base, head)
+          Patches.new(self, merge_base, patches)
+        end
       end
 
       def show_commit(sha)


### PR DESCRIPTION
Hi,

I could not find a way to run pronto on the staging area so I added `-i` option.

What do you think?

Note: I couldn't find specs neither for `Pronto::Git::Repository` nor for `Pronto::CLI` so I did not add more specs :( Sorry for that!

---

After this commit you can run pronto on your current
staging area (git index).

This way you can analyze _before_ you commit.

Usage:

```
pronto run -i
```
