### PR TITLE
Add the new pronto-coffeelint runner to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,4 @@ Currently available:
 * [pronto-spell](https://github.com/mmozuras/pronto-spell)
 * [pronto-haml](https://github.com/mmozuras/pronto-haml)
 * [pronto-scss](https://github.com/mmozuras/pronto-scss)
+* [pronto-coffeelint](https://github.com/siebertm/pronto-coffeelint)


### PR DESCRIPTION
I quickly created a runner for coffeelint, which lints .coffee files (shamelessly copied and adapted from pronto-jshint). Add this to the README file
