### PR TITLE
Sets correct gitlab dependency for gitlab formatter

### DIFF
--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'rugged', '~> 0.21.0'
   s.add_runtime_dependency 'thor', '~> 0.19.0'
   s.add_runtime_dependency 'octokit', '~> 3.2'
-  s.add_runtime_dependency 'gitlab', '~> 3.2'
+  s.add_runtime_dependency 'gitlab', '~> 3.3'
   s.add_development_dependency 'rake', '~> 10.3'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rspec-its', '~> 1.0'


### PR DESCRIPTION
gitlab 3.3 was released which includes the neccesary code for the gitlab formatter :thumbsup:
