### PR TITLE
When HEAD is detached find GitHub PR by SHA 

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,3 +17,6 @@ Metrics/BlockLength:
   ExcludedMethods: Struct.new
   Exclude:
     - spec/**/*.rb
+
+Rubocop/Metrics/AbcSize:
+  Max: 25

--- a/lib/pronto/git/repository.rb
+++ b/lib/pronto/git/repository.rb
@@ -66,6 +66,10 @@ module Pronto
         head.oid
       end
 
+      def head_detached?
+        @repo.head_detached?
+      end
+
       private
 
       def empty_patches(sha)

--- a/lib/pronto/github.rb
+++ b/lib/pronto/github.rb
@@ -92,6 +92,10 @@ module Pronto
                   pull_requests.find { |pr| pr[:number].to_i == env_pull_id }
                 elsif @repo.branch
                   pull_requests.find { |pr| pr[:head][:ref] == @repo.branch }
+                elsif @repo.head_detached?
+                  pull_requests.find do |pr|
+                    pr[:head][:sha] == @repo.head_commit_sha
+                  end
                 end
     end
 

--- a/spec/pronto/github_spec.rb
+++ b/spec/pronto/github_spec.rb
@@ -3,7 +3,7 @@ module Pronto
     let(:github) { described_class.new(repo) }
 
     let(:repo) do
-      double(remote_urls: ['git@github.com:prontolabs/pronto.git'], branch: nil)
+      double(remote_urls: ['git@github.com:prontolabs/pronto.git'], branch: nil, head_detached?: false)
     end
     let(:sha) { '61e4bef' }
     let(:comment) { double(body: 'note', path: 'path', line: 1, position: 1) }


### PR DESCRIPTION
I've been trying to use the GithubPullRequestReviewFormatter with a Jenkins pipeline but ran into a problem. Jenkins doesn't expose the PR number and it checks out the commit from the webhook rather than the branch. The best fix I could come up with was modifying pronto to find the PR based off the SHA if the repo has a detached HEAD.

I wasn't sure if this would be an acceptable change so I didn't bother with any specs. If it's something you'd consider merging I'm happy to add tests.