### PR TITLE
Fix ${line} in text format to mean line number

### DIFF
--- a/lib/pronto/formatter/text_message_decorator.rb
+++ b/lib/pronto/formatter/text_message_decorator.rb
@@ -16,6 +16,7 @@ module Pronto
 
       def to_h
         original = __getobj__.to_h
+        original[:line] = __getobj__.line.new_lineno if __getobj__.line
         original[:color_level] = format_level(__getobj__)
         original[:color_location] = format_location(__getobj__)
         original

--- a/spec/pronto/formatter/text_formatter_spec.rb
+++ b/spec/pronto/formatter/text_formatter_spec.rb
@@ -42,6 +42,16 @@ module Pronto
           its(:first) { should == 'W: careful' }
         end
 
+        context 'with custom config' do
+          before do
+            formatter.stub(:config) do
+              Config.new('text' => { 'format' => '%{line} %{path}' })
+            end
+          end
+          its(:count) { should == 2 }
+          its(:first) { should == '1 path/to' }
+        end
+
         context 'in TTY' do
           before { $stdout.stub(:tty?) { true } }
 


### PR DESCRIPTION
**How to reproduce:**

Create a reasonable-sounding .pronto.yml that looks like this, based on documentation from https://github.com/prontolabs/pronto#message-format:

```
 text:
   format: "%{path} %{line} %{runner} %{msg}"
```

Run against a project

**Expected results:**

Receive text output that looks like this:

```
Rakefile 124 rubocop Use `%i` or `%I` for an array of symbols.
```

**Observed results:**

```
Rakefile #<struct Pronto::Git::Line line=#<Rugged::Diff::Line:70253771778400 {line_origin: :addition, content: "task quality: [:pronto, :update_bundle_audit]\n">, patch=#<struct Pronto::Git::Patch patch=#<Rugged::Patch:70253763427640>, repo=#<Pronto::Git::Repository:0x007fca7539fe08 @repo=#<Rugged::Repository:70253763428080 {path: "/Users/broz/src/vincelifedaily/.git/"}>>>, hunk=#<Rugged::Diff::Hunk:70253771778940 {header: "@@ -115,7 +115,13 @@ end\n", count: 14}>> rubocop Use `%i` or `%I` for an array of symbols.
```

**Notes:**

Looks like the json_formatter.rb already looks for line number via the same method I'm proposing here.  I'm guessing changing the meaning of `message.line` is a nonstarter given you'd have to change all of the runners at the same time, so using the decorator to adjust the meaning seemed like the right thing.