### PR TITLE
Change link to an existing article about Pronto

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ Articles to help you to get started:
 * [Continuous Static Analysis using Pronto](http://codingfearlessly.com/2014/11/06/continuous-static-analysis/)
 * [Pronto and git hooks](http://elliotthilaire.net/gem-pronto-and-git-hooks/)
 * [How to end fruitless dev discussions about your project’s code style?](https://medium.com/appaloosa-store-engineering/how-to-end-fruitless-dev-discussions-about-your-project-s-code-style-245070bff6d4)
-* [Free automated code reviews using Pronto](https://hovancik.net/blog/2016/04/11/free-automated-code-reviews-using-pronto.html)
+* [Free automated code reviews using Pronto](https://hovancik.net/blog/2016/04/11/free-automated-code-reviews-using-pronto/)
 * [Automated Elixir code review with Github, Credo and Travis CI](https://medium.com/fazibear/automated-elixir-code-review-with-github-credo-and-travis-ci-986cd56b8f02)
 * [Running Rubocop before git commit](https://christoph.luppri.ch/articles/2016/11/21/running-rubocop-before-git-commit/)
 * [Pronto, Codeship and GitHub for automatic code review](http://abinoam.tl1n.com/pronto-codeship-and-github-for-automatic-code-review/)


### PR DESCRIPTION
URL 

https://hovancik.net/blog/2016/04/11/free-automated-code-reviews-using-pronto.html 

changed to 

https://hovancik.net/blog/2016/04/11/free-automated-code-reviews-using-pronto/