### PR TITLE
Convert `PRONTO_MAX_WARNINGS` to Integer

### DIFF
--- a/lib/pronto/config.rb
+++ b/lib/pronto/config.rb
@@ -40,7 +40,7 @@ module Pronto
     end
 
     def max_warnings
-      ENV['PRONTO_MAX_WARNINGS'] || @config_hash['max_warnings']
+      ENV['PRONTO_MAX_WARNINGS'] && ENV['PRONTO_MAX_WARNINGS'].to_i || @config_hash['max_warnings']
     end
 
     def message_format(formatter)

--- a/lib/pronto/config.rb
+++ b/lib/pronto/config.rb
@@ -40,7 +40,7 @@ module Pronto
     end
 
     def max_warnings
-      ENV['PRONTO_MAX_WARNINGS'] && ENV['PRONTO_MAX_WARNINGS'].to_i || @config_hash['max_warnings']
+      ENV['PRONTO_MAX_WARNINGS'] && Integer(ENV['PRONTO_MAX_WARNINGS']) || @config_hash['max_warnings']
     end
 
     def message_format(formatter)

--- a/spec/pronto/config_spec.rb
+++ b/spec/pronto/config_spec.rb
@@ -56,6 +56,25 @@ module Pronto
       end
     end
 
+    describe '#max_warnings' do
+      subject { config.max_warnings }
+
+      context 'from env variable' do
+        before { stub_const('ENV', 'PRONTO_MAX_WARNINGS' => '20') }
+        it { should == 20 }
+      end
+
+      context 'from config hash' do
+        let(:config_hash) { { 'max_warnings' => 40 } }
+        it { should == 40 }
+      end
+
+      context 'default' do
+        let(:config_hash) { ConfigFile::EMPTY }
+        it { should == nil }
+      end
+    end
+
     describe '#message_format' do
       subject { config.message_format('whatever') }
 

--- a/spec/pronto/config_spec.rb
+++ b/spec/pronto/config_spec.rb
@@ -60,8 +60,18 @@ module Pronto
       subject { config.max_warnings }
 
       context 'from env variable' do
-        before { stub_const('ENV', 'PRONTO_MAX_WARNINGS' => '20') }
-        it { should == 20 }
+        context 'with a valid value' do
+          before { stub_const('ENV', 'PRONTO_MAX_WARNINGS' => '20') }
+          it { should == 20 }
+        end
+
+        context 'with an invalid value' do
+          before { stub_const('ENV', 'PRONTO_MAX_WARNINGS' => 'twenty') }
+
+          specify do
+            -> { subject }.should raise_error(ArgumentError)
+          end
+        end
       end
 
       context 'from config hash' do


### PR DESCRIPTION
**What does this do?**
It converts `PRONTO_MAX_WARNINGS` from String to Integer.

**Why?**
ENV variables are always read as Strings. So when trying to set this from an environment variable an exception is raised in [`Pronto::Runners#exceeds_max?`](https://github.com/prontolabs/pronto/blob/master/lib/pronto/runners.rb#L37) since it tries to compare an Integer to a String.

**How to test this?**
The issue can be reproduced on the latest version simply by setting max warnings through ENV:
```shell
⇒  PRONTO_MAX_WARNINGS=1 pronto run
ArgumentError: comparison of Integer with String failed
```