### PR TITLE
Add bitbucket auto approve pull request feature

### DIFF
--- a/lib/pronto/bitbucket.rb
+++ b/lib/pronto/bitbucket.rb
@@ -32,6 +32,13 @@ module Pronto
       end
     end
 
+    def approve_pull_request
+      client.approve_pull_request(slug, pull_id)
+    end
+
+    def unapprove_pull_request
+      client.unapprove_pull_request(slug, pull_id)
+    end
     private
 
     def slug

--- a/lib/pronto/clients/bitbucket_client.rb
+++ b/lib/pronto/clients/bitbucket_client.rb
@@ -21,8 +21,7 @@ class BitbucketClient
   end
 
   def pull_requests(slug)
-    base = 'https://api.bitbucket.org/2.0/repositories'
-    response = get("#{base}/#{slug}/pullrequests?state=OPEN")
+    response = get("#{pull_request_api(slug)}/pullrequests?state=OPEN")
     openstruct(response['values'])
   end
 
@@ -30,7 +29,19 @@ class BitbucketClient
     post("/#{slug}/pullrequests/#{pull_id}/comments", body, path, position)
   end
 
+  def approve_pull_request(slug, pull_id)
+    self.class.post("#{pull_request_api(slug)}/pullrequests/#{pull_id}/approve")
+  end
+
+  def unapprove_pull_request(slug, pull_id)
+    self.class.delete("#{pull_request_api(slug)}/pullrequests/#{pull_id}/approve")
+  end
+
   private
+
+  def pull_request_api(slug)
+    "https://api.bitbucket.org/2.0/repositories/#{slug}"
+  end
 
   def openstruct(response)
     response.map { |r| OpenStruct.new(r) }

--- a/lib/pronto/config_file.rb
+++ b/lib/pronto/config_file.rb
@@ -23,6 +23,7 @@ module Pronto
         'username' => nil,
         'password' => nil,
         'api_endpoint' => nil,
+        'auto_approve' => false,
         'web_endpoint' => 'https://bitbucket.org/'
       },
       'text' => {

--- a/lib/pronto/formatter/bitbucket_pull_request_formatter.rb
+++ b/lib/pronto/formatter/bitbucket_pull_request_formatter.rb
@@ -12,6 +12,16 @@ module Pronto
       def line_number(message, _)
         message.line.line.new_lineno if message.line
       end
+
+      def approve_pull_request(comments_count, additions_count, client)
+        return if @config.bitbucket_auto_approve == false
+
+        if comments_count > 0 && additions_count > 0
+          client.unapprove_pull_request  
+        elsif comments_count == 0
+          client.approve_pull_request
+        end
+      end
     end
   end
 end

--- a/lib/pronto/formatter/bitbucket_pull_request_formatter.rb
+++ b/lib/pronto/formatter/bitbucket_pull_request_formatter.rb
@@ -14,7 +14,7 @@ module Pronto
       end
 
       def approve_pull_request(comments_count, additions_count, client)
-        return if @config.bitbucket_auto_approve == false
+        return if config.bitbucket_auto_approve == false
 
         if comments_count > 0 && additions_count > 0
           client.unapprove_pull_request  

--- a/lib/pronto/formatter/git_formatter.rb
+++ b/lib/pronto/formatter/git_formatter.rb
@@ -7,6 +7,8 @@ module Pronto
         comments = new_comments(messages, patches)
         additions = remove_duplicate_comments(existing, comments)
         submit_comments(client, additions)
+        
+        approve_pull_request(comments.count, additions.count, client) if defined?(self.approve_pull_request)
 
         "#{additions.count} Pronto messages posted to #{pretty_name}"
       end

--- a/spec/pronto/clients/bitbucket_client_spec.rb
+++ b/spec/pronto/clients/bitbucket_client_spec.rb
@@ -16,5 +16,29 @@ module Pronto
         its(:success?) { should be_truthy }
       end
     end
+
+    describe '#approve_pull_request' do
+      subject { client.approve_pull_request(slug, pull_id) }
+      let(:slug) { 'prontolabs/pronto' }
+      let(:pull_id) { 1 }
+
+      context 'success' do
+        before { BitbucketClient.stub(:post).and_return(response) }
+        let(:response) { double('Response', success?: true) }
+        its(:success?) { should be_truthy }
+      end
+    end
+
+    describe '#unapprove_pull_request' do
+      subject { client.unapprove_pull_request(slug, pull_id) }
+      let(:slug) { 'prontolabs/pronto' }
+      let(:pull_id) { 1 }
+
+      context 'success' do
+        before { BitbucketClient.stub(:delete).and_return(response) }
+        let(:response) { double('Response', success?: true) }
+        its(:success?) { should be_truthy }
+      end
+    end
   end
 end


### PR DESCRIPTION
I'm using bitbucket and pronto to auto check style violations in pull request, but there are no way to know if a pull request is checked or not. So I added an approve option to let us know which pull request is checked.

Just set auto_approve: true 

![Screenshot](https://i.imgur.com/m6CmMiF.png)

And here is the result 

![Screenshot](https://i.imgur.com/HI7Kf21.png)