### PR TITLE
Update rainbow and solve conflict with rubocop dependencies

### DIFF
--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('gitlab', '~> 4.0', '>= 4.0.0')
   s.add_runtime_dependency('httparty', '>= 0.13.7')
   s.add_runtime_dependency('octokit', '~> 4.7', '>= 4.7.0')
-  s.add_runtime_dependency('rainbow', '>= 2.2', '< 4.0')
+  s.add_runtime_dependency('rainbow', '>= 2.2.2', '< 4.0')
   s.add_runtime_dependency('rugged', '~> 0.24', '>= 0.23.0')
   s.add_runtime_dependency('thor', '~> 0.20.0')
   s.add_development_dependency('bundler', '~> 1.3')


### PR DESCRIPTION
Hi guys,

This PR resolves compatibility issues with rubocop. The rubocop needs the rainbow in the version> = 2.2.2. It is conflicting between the last version of the pronto and the rubocop when installing the gem in a project. In addition, the latest version published in rubygems requires version 2.1 exactly, and it's broken with rubocop (>= 2.2.2).

![firefox_screenshot_2018-08-07t21-26-04 813z](https://user-images.githubusercontent.com/13274722/43803563-8f936934-9a6f-11e8-87b8-d76ea1394459.png) Runtime dependence of pronto.

[Rubocop dependence](https://github.com/rubocop-hq/rubocop/blob/master/rubocop.gemspec#L41)

This PR uses the same version of the lasted version of the rainbow gem from the rubocop gem.
:smile_cat: 