### PR TITLE
Add pronto-goodcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,6 +303,7 @@ Currently available:
 * [pronto-textlint](https://github.com/seikichi/pronto-textlint)
 * [pronto-tslint_npm](https://github.com/eprislac/pronto-tslint_npm)
 * [pronto-yamllint](https://github.com/pauliusm/pronto-yamllint)
+* [pronto-goodcheck](https://github.com/aergonaut/pronto-goodcheck)
 
 ## Articles
 


### PR DESCRIPTION
Add link to [pronto-goodcheck](https://github.com/aergonaut/pronto-goodcheck).

Note: This depends on the [unreleased change to allow rainbow 3.0](https://github.com/prontolabs/pronto/pull/287), so this shouldn't be merged until that change is released to avoid confusing people. I think the version conflict can be ignored if using Bundler and pronto is specified as a Git dependency instead of from RubyGems. But I think we would rather have people using RubyGems, and this also doesn't work for someone who isn't using Bundler.

cc @prontolabs/core 