### PR TITLE
Add support OAuth2 and consumers authentication

### DIFF
--- a/lib/pronto/bitbucket.rb
+++ b/lib/pronto/bitbucket.rb
@@ -42,19 +42,27 @@ module Pronto
     private
 
     def slug
-      return @config.bitbucket_slug if @config.bitbucket_slug
+      return bitbucket_slug if bitbucket_slug
       @slug ||= begin
         @repo.remote_urls.map do |url|
-          hostname = Regexp.escape(@config.bitbucket_hostname)
+          hostname = Regexp.escape(bitbucket_hostname)
           match = %r{.*#{hostname}(:|\/)(?<slug>.*?)(?:\.git)?\z}.match(url)
           match[:slug] if match
         end.compact.first
       end
     end
 
+    def bitbucket_hostname
+      @config.bitbucket_hostname
+    end
+
+    def bitbucket_slug
+      @config.bitbucket_slug
+    end
+
     def client
-      @client ||= BitbucketClient.new(@config.bitbucket_username,
-                                      @config.bitbucket_password)
+      @client ||= BitbucketClient.new(@config.bitbucket_key,
+                                      @config.bitbucket_secret)
     end
 
     def pull_id

--- a/lib/pronto/bitbucket_server.rb
+++ b/lib/pronto/bitbucket_server.rb
@@ -15,9 +15,9 @@ module Pronto
     private
 
     def client
-      @client ||= BitbucketServerClient.new(@config.bitbucket_username,
-                                            @config.bitbucket_password,
-                                            @config.bitbucket_api_endpoint)
+      @client ||= BitbucketServerClient.new(@config.bitbucket_server_username,
+                                            @config.bitbucket_server_password,
+                                            @config.bitbucket_server_api_endpoint)
     end
 
     def pull
@@ -28,6 +28,14 @@ module Pronto
                     pr['fromRef']['displayId'] == @repo.branch
                   end
                 end
+    end
+
+    def bitbucket_hostname
+      @config.bitbucket_server_hostname
+    end
+
+    def bitbucket_slug
+      @config.bitbucket_server_slug
     end
   end
 end

--- a/lib/pronto/clients/bitbucket_client.rb
+++ b/lib/pronto/clients/bitbucket_client.rb
@@ -1,27 +1,35 @@
 class BitbucketClient
-  include HTTParty
-  base_uri 'https://api.bitbucket.org/1.0/repositories'
+  BITBUCKET_ACCESS_TOKEN_URL = "https://bitbucket.org/site/oauth2/access_token".freeze
+  BITBUCKET_ACCESS_TOKEN_PAYLOAD = { grant_type: :client_credentials }.freeze
 
-  def initialize(username, password)
-    self.class.basic_auth(username, password)
+  include HTTParty
+  base_uri 'https://api.bitbucket.org/2.0/repositories'
+
+  def initialize(key, secret)
+    options = {
+      basic_auth: { username: key, password: secret },
+      body: BITBUCKET_ACCESS_TOKEN_PAYLOAD
+    }
+
+    self.response = self.class.post(BITBUCKET_ACCESS_TOKEN_URL, options)
   end
 
   def commit_comments(slug, sha)
-    response = get("/#{slug}/changesets/#{sha}/comments")
+    response = get("/#{slug}/commit/#{sha}/comments")
     openstruct(response)
   end
 
   def create_commit_comment(slug, sha, body, path, position)
-    post("/#{slug}/changesets/#{sha}/comments", body, path, position)
+    post("/#{slug}/commit/#{sha}/comments", body, path, position)
   end
 
   def pull_comments(slug, pull_id)
     response = get("/#{slug}/pullrequests/#{pull_id}/comments")
-    openstruct(response)
+    openstruct(response['values'])
   end
 
   def pull_requests(slug)
-    response = get("#{pull_request_api(slug)}/pullrequests?state=OPEN")
+    response = get("/#{slug}/pullrequests?state=OPEN")
     openstruct(response['values'])
   end
 
@@ -30,18 +38,16 @@ class BitbucketClient
   end
 
   def approve_pull_request(slug, pull_id)
-    self.class.post("#{pull_request_api(slug)}/pullrequests/#{pull_id}/approve")
+    self.class.post("#{slug}/pullrequests/#{pull_id}/approve" ,access_token_options)
   end
 
   def unapprove_pull_request(slug, pull_id)
-    self.class.delete("#{pull_request_api(slug)}/pullrequests/#{pull_id}/approve")
+    self.class.delete("#{slug}/pullrequests/#{pull_id}/approve", access_token_options)
   end
 
   private
 
-  def pull_request_api(slug)
-    "https://api.bitbucket.org/2.0/repositories/#{slug}"
-  end
+  attr_reader :response
 
   def openstruct(response)
     response.map { |r| OpenStruct.new(r) }
@@ -50,15 +56,46 @@ class BitbucketClient
   def post(url, body, path, position)
     options = {
       body: {
-        content: body,
-        line_to: position,
-        filename: path
-      }
+        content: { raw: body },
+        inline: {
+          to: position,
+          path: path
+        }
+      }.to_json,
+      headers: {
+        "Content-Type" => "application/json",
+        **access_token_header
+      },
+      query: access_token_query
     }
+
     self.class.post(url, options)
   end
 
   def get(url)
-    self.class.get(url).parsed_response
+    self.class.get(url, access_token_options).parsed_response
+  end
+
+  def access_token_options
+    {
+      query: access_token_query,
+      headers: access_token_header
+    }
+  end
+
+  def access_token_query
+    { access_token: access_token }
+  end
+
+  def access_token_header
+    { "Authorization": "Bearer #{access_token}" }
+  end
+
+  def access_token
+    response[:access_token]
+  end
+
+  def response=(response)
+    @response = JSON.parse(response.body, symbolize_names: true)
   end
 end

--- a/lib/pronto/config.rb
+++ b/lib/pronto/config.rb
@@ -4,7 +4,7 @@ module Pronto
       @config_hash = config_hash
     end
 
-    %w[github gitlab bitbucket].each do |service|
+    %w[github gitlab bitbucket bitbucket_server].each do |service|
       ConfigFile::EMPTY[service].each do |key, _|
         name = "#{service}_#{key}"
         define_method(name) { ENV["PRONTO_#{name.upcase}"] || @config_hash[service][key] }
@@ -37,6 +37,10 @@ module Pronto
 
     def bitbucket_hostname
       URI.parse(bitbucket_web_endpoint).host
+    end
+
+    def bitbucket_server_hostname
+      URI.parse(bitbucket_server_web_endpoint).host
     end
 
     def max_warnings

--- a/lib/pronto/config_file.rb
+++ b/lib/pronto/config_file.rb
@@ -20,6 +20,14 @@ module Pronto
       },
       'bitbucket' => {
         'slug' => nil,
+        'key' => nil,
+        'secret' => nil,
+        'api_endpoint' => nil,
+        'auto_approve' => false,
+        'web_endpoint' => 'https://bitbucket.org/'
+      },
+      'bitbucket_server' => {
+        'slug' => nil,
         'username' => nil,
         'password' => nil,
         'api_endpoint' => nil,

--- a/spec/pronto/clients/bitbucket_client_spec.rb
+++ b/spec/pronto/clients/bitbucket_client_spec.rb
@@ -12,7 +12,7 @@ module Pronto
 
       context 'success' do
         before { BitbucketClient.stub(:post).and_return(response) }
-        let(:response) { double('Response', success?: true) }
+        let(:response) { double('Response', success?: true, body: {}.to_json) }
         its(:success?) { should be_truthy }
       end
     end
@@ -24,7 +24,7 @@ module Pronto
 
       context 'success' do
         before { BitbucketClient.stub(:post).and_return(response) }
-        let(:response) { double('Response', success?: true) }
+        let(:response) { double('Response', success?: true, body: {}.to_json) }
         its(:success?) { should be_truthy }
       end
     end


### PR DESCRIPTION
Bitbucket Cloud v1 APIs are deprecated

Bitbucket Cloud REST API version 1 is deprecated effective 30 June 2018. All 1.0 APIs will be removed from the REST API permanently on 31 December 2018.