### PR TITLE
Fix for GithubSpec Test (fixes #324)

### DIFF
--- a/spec/pronto/github_spec.rb
+++ b/spec/pronto/github_spec.rb
@@ -165,7 +165,7 @@ module Pronto
 
         specify do
           octokit_client
-            .should_not_receive(:create_pull_request_review)
+            .should_receive(:create_pull_request_review)
             .with('prontolabs/pronto', pull_id, options)
             .once
 


### PR DESCRIPTION
The `Pronto::Github#create_pull_request_review with comments` test in master branch are failing as per issue #324. This PR fixes it.