### PR TITLE
Updated GitHub Accept Header for create_pull_request_review_with_comments (fixes #326)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ before_install: gem update --system
 dist: trusty
 language: ruby
 rvm:
-- 2.2
 - 2.3
 - 2.4
 - 2.5

--- a/lib/pronto/github.rb
+++ b/lib/pronto/github.rb
@@ -50,7 +50,7 @@ module Pronto
 
       options = {
         event: 'COMMENT',
-        accept: 'application/vnd.github.black-cat-preview+json', # https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
+        accept: 'application/vnd.github.v3.diff+json', # https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
         comments: comments.map do |c|
           { path: c.path, position: c.position, body: c.body }
         end

--- a/spec/pronto/github_spec.rb
+++ b/spec/pronto/github_spec.rb
@@ -155,7 +155,7 @@ module Pronto
         let(:options) do
           {
             event: 'COMMENT',
-            accept: 'application/vnd.github.black-cat-preview+json',
+            accept: 'application/vnd.github.v3.diff+json',
             comments: [
               { path: 'bad_file.rb', position: 10, body: 'Offense #1' },
               { path: 'bad_file.rb', position: 20, body: 'Offense #2' }

--- a/spec/pronto/github_spec.rb
+++ b/spec/pronto/github_spec.rb
@@ -165,7 +165,7 @@ module Pronto
 
         specify do
           octokit_client
-            .should_not_receive(:create_pull_request_review)
+            .should_receive(:create_pull_request_review)
             .with('prontolabs/pronto', pull_id, options)
             .once
 


### PR DESCRIPTION
The current implementation of `Github.create_pull_request_review` sends the wrong `Accept` header sends the wrong type. This PR updates it with the correct one according to [their docs](https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review).