### PR TITLE
Add configurable Github review_type with 'REQUEST_CHANGES' as default

### DIFF
--- a/lib/pronto/config.rb
+++ b/lib/pronto/config.rb
@@ -23,10 +23,10 @@ module Pronto
         ENV['PRONTO_GITHUB_REVIEW_TYPE'] ||
         @config_hash.fetch('github_review_type', false)
 
-      if review_type == 'comment'
-        'COMMENT'
-      else
+      if review_type == 'request_changes'
         'REQUEST_CHANGES'
+      else
+        'COMMENT'
       end
     end
 

--- a/lib/pronto/config.rb
+++ b/lib/pronto/config.rb
@@ -18,6 +18,18 @@ module Pronto
       consolidated
     end
 
+    def github_review_type
+      review_type =
+        ENV['PRONTO_GITHUB_REVIEW_TYPE'] ||
+        @config_hash.fetch('github_review_type', false)
+
+      if review_type == 'comment'
+        'COMMENT'
+      else
+        'REQUEST_CHANGES'
+      end
+    end
+
     def excluded_files(runner)
       files =
         if runner == 'all'

--- a/lib/pronto/config_file.rb
+++ b/lib/pronto/config_file.rb
@@ -12,7 +12,8 @@ module Pronto
         'slug' => nil,
         'access_token' => nil,
         'api_endpoint' => 'https://api.github.com/',
-        'web_endpoint' => 'https://github.com/'
+        'web_endpoint' => 'https://github.com/',
+        'review_type' => 'request_changes'
       },
       'gitlab' => {
         'slug' => nil,

--- a/lib/pronto/github.rb
+++ b/lib/pronto/github.rb
@@ -65,10 +65,10 @@ module Pronto
 
     def create_pull_request_review(comments)
       options = {
-        event: 'COMMENT',
+        event: @config.github_review_type,
         accept: 'application/vnd.github.v3.diff+json', # https://developer.github.com/v3/pulls/reviews/#create-a-pull-request-review
         comments: comments.map do |comment|
-          { 
+          {
             path:     comment.path,
             position: comment.position,
             body:     comment.body

--- a/spec/pronto/config_file_spec.rb
+++ b/spec/pronto/config_file_spec.rb
@@ -13,7 +13,8 @@ module Pronto
               'slug' => nil,
               'access_token' => nil,
               'api_endpoint' => 'https://api.github.com/',
-              'web_endpoint' => 'https://github.com/'
+              'web_endpoint' => 'https://github.com/',
+              'review_type' => 'request_changes'
             }
           )
         end

--- a/spec/pronto/config_spec.rb
+++ b/spec/pronto/config_spec.rb
@@ -46,18 +46,18 @@ module Pronto
       subject { config.github_review_type }
 
       context 'from env variable' do
-        before { stub_const('ENV', 'PRONTO_GITHUB_REVIEW_TYPE' => 'comment') }
-        it { should == 'COMMENT' }
+        before { stub_const('ENV', 'PRONTO_GITHUB_REVIEW_TYPE' => 'request_changes') }
+        it { should == 'REQUEST_CHANGES' }
       end
 
       context 'from config hash' do
         let(:config_hash) { { 'github' => { 'review_type' => 'something_else' } } }
-        it { should == 'REQUEST_CHANGES' }
+        it { should == 'COMMENT' }
       end
 
       context 'default' do
         let(:config_hash) { ConfigFile::EMPTY }
-        it { should == 'REQUEST_CHANGES' }
+        it { should == 'COMMENT' }
       end
     end
 

--- a/spec/pronto/config_spec.rb
+++ b/spec/pronto/config_spec.rb
@@ -42,6 +42,25 @@ module Pronto
       it { should == 'github.com' }
     end
 
+    describe '#github_review_type' do
+      subject { config.github_review_type }
+
+      context 'from env variable' do
+        before { stub_const('ENV', 'PRONTO_GITHUB_REVIEW_TYPE' => 'comment') }
+        it { should == 'COMMENT' }
+      end
+
+      context 'from config hash' do
+        let(:config_hash) { { 'github' => { 'review_type' => 'something_else' } } }
+        it { should == 'REQUEST_CHANGES' }
+      end
+
+      context 'default' do
+        let(:config_hash) { ConfigFile::EMPTY }
+        it { should == 'REQUEST_CHANGES' }
+      end
+    end
+
     describe '#gitlab_slug' do
       subject { config.gitlab_slug }
 

--- a/spec/pronto/github_spec.rb
+++ b/spec/pronto/github_spec.rb
@@ -8,7 +8,7 @@ module Pronto
     let(:comment) { double(body: 'note', path: 'path', line: 1, position: 1) }
     let(:empty_client_options) do
       {
-        event: 'COMMENT',
+        event: 'REQUEST_CHANGES',
         accept: 'application/vnd.github.v3.diff+json'
       }
     end

--- a/spec/pronto/github_spec.rb
+++ b/spec/pronto/github_spec.rb
@@ -8,7 +8,7 @@ module Pronto
     let(:comment) { double(body: 'note', path: 'path', line: 1, position: 1) }
     let(:empty_client_options) do
       {
-        event: 'REQUEST_CHANGES',
+        event: 'COMMENT',
         accept: 'application/vnd.github.v3.diff+json'
       }
     end


### PR DESCRIPTION
NOTE: This PR is a replacement for PR #320 which lost its traction.

## Issue
#319 

## Implements
Similarly to #320 this adds `REQUEST_CHANGES` as the default event, with some more code around the configurability and specs for that.