### PR TITLE
[WIP] Remove outdated comments

### DIFF
--- a/lib/pronto/comment.rb
+++ b/lib/pronto/comment.rb
@@ -1,5 +1,5 @@
 module Pronto
-  Comment = Struct.new(:sha, :body, :path, :position) do
+  Comment = Struct.new(:sha, :body, :path, :position, :id) do
     def ==(other)
       position == other.position &&
         path == other.path &&

--- a/lib/pronto/formatter/git_formatter.rb
+++ b/lib/pronto/formatter/git_formatter.rb
@@ -4,8 +4,12 @@ module Pronto
       def format(messages, repo, patches)
         client = client_module.new(repo)
         existing = existing_comments(messages, client, repo)
+        outdated = outdated_comments(existing)
+        existing -= outdated
         comments = new_comments(messages, patches)
         additions = remove_duplicate_comments(existing, comments)
+
+        remove_comemnts(client, outdated)
         submit_comments(client, additions)
         
         approve_pull_request(comments.count, additions.count, client) if defined?(self.approve_pull_request)
@@ -90,6 +94,10 @@ module Pronto
             memo.concat(comments)
           end
         end
+      end
+
+      def outdated_comments(comments)
+        comments.select { |comment| comment.position = nil }
       end
     end
   end

--- a/lib/pronto/formatter/pull_request_formatter.rb
+++ b/lib/pronto/formatter/pull_request_formatter.rb
@@ -7,6 +7,12 @@ module Pronto
         grouped_comments(comments)
       end
 
+      def remove_comments(client, comments)
+        comments.each { |comment| client.delete_pull_comment(comment) }
+      rescue Octokit::UnprocessableEntity, HTTParty::Error => e
+        $stderr.puts "Failed to post: #{e.message}"
+      end
+
       def submit_comments(client, comments)
         comments.each { |comment| client.create_pull_comment(comment) }
       rescue Octokit::UnprocessableEntity, HTTParty::Error => e

--- a/lib/pronto/github.rb
+++ b/lib/pronto/github.rb
@@ -10,8 +10,7 @@ module Pronto
     def pull_comments(sha)
       @comment_cache["#{pull_id}/#{sha}"] ||= begin
         client.pull_comments(slug, pull_id).map do |comment|
-          Comment.new(sha, comment.body, comment.path,
-                      comment.position || comment.original_position)
+          Comment.new(sha, comment.body, comment.path, comment.position, comment.id)
         end
       end
     rescue Octokit::NotFound => e
@@ -23,7 +22,7 @@ module Pronto
     def commit_comments(sha)
       @comment_cache[sha.to_s] ||= begin
         client.commit_comments(slug, sha).map do |comment|
-          Comment.new(sha, comment.body, comment.path, comment.position)
+          Comment.new(sha, comment.body, comment.path, comment.position, comment.id)
         end
       end
     end
@@ -32,6 +31,10 @@ module Pronto
       @config.logger.log("Creating commit comment on #{comment.sha}")
       client.create_commit_comment(slug, comment.sha, comment.body,
                                    comment.path, nil, comment.position)
+    end
+
+    def delete_pull_comment(comment)
+      client.delete_pull_request_comment(slug, comment.id)
     end
 
     def create_pull_comment(comment)


### PR DESCRIPTION
**This is a work in progress PR, which I submitted to collect feedback along the way.**

The idea is that if a comment doesn't have a line (or had a line and doesn't have one anymore), it's outdated and we can remove it on next pass. This info is very easy to get from the Github API; not sure about Bitbucket and Gitlab yet.

I think that with keeping this option off as a default, it may be a nice addition to pronto.

Remaining TODOs:

- [ ] Add the `remove outdated comments` option to config
- [ ] Cleanup Github implementation
- [ ] Implement Bitbucket
- [ ] Implement Gitlab