### PR TITLE
readme: add a pointer to a new runner built to run 'hlint' linter

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Currently available:
 * [pronto-foodcritic](https://github.com/prontolabs/pronto-foodcritic)
 * [pronto-goodcheck](https://github.com/aergonaut/pronto-goodcheck)
 * [pronto-haml](https://github.com/prontolabs/pronto-haml)
+* [pronto-hlint](https://github.com/fretlink/pronto-hlint/) (uses Haskell code suggestions [hlint](https://github.com/ndmitchell/hlint))
 * [pronto-inspec](https://github.com/stiller-leser/pronto-inspec)
 * [pronto-jscs](https://github.com/spajus/pronto-jscs)
 * [pronto-jshint](https://github.com/prontolabs/pronto-jshint)


### PR DESCRIPTION
We had the need to be able to run `hlint` in our codebase as a haskell
programmers so we created the [`pronto-hlint`](https://github.com/fretlink/pronto-hlint/)
 gem.

This PR adds a mention in the readme of Pronto.