### PR TITLE
Treat Gemfile and .gemspecs as Ruby

### DIFF
--- a/lib/pronto/runner.rb
+++ b/lib/pronto/runner.rb
@@ -28,7 +28,10 @@ module Pronto
     end
 
     def ruby_file?(path)
-      rb_file?(path) || rake_file?(path) || ruby_executable?(path)
+      rb_file?(path) ||
+        rake_file?(path) ||
+        gem_file?(path) ||
+        ruby_executable?(path)
     end
 
     def repo_path
@@ -43,6 +46,10 @@ module Pronto
 
     def rake_file?(path)
       File.extname(path) == '.rake'
+    end
+
+    def gem_file?(path)
+      File.basename(path) == 'Gemfile' || File.extname(path) == '.gemspec'
     end
 
     def ruby_executable?(path)

--- a/spec/pronto/runner_spec.rb
+++ b/spec/pronto/runner_spec.rb
@@ -32,7 +32,7 @@ module Pronto
       end
 
       context 'named Gemfile' do
-        let(:path) { 'test/Gemfile' }
+        let(:path) { 'Gemfile' }
         it { should be_truthy }
       end
 

--- a/spec/pronto/runner_spec.rb
+++ b/spec/pronto/runner_spec.rb
@@ -26,6 +26,21 @@ module Pronto
         it { should be_truthy }
       end
 
+      context 'ending with .gemspec' do
+        let(:path) { 'test.gemspec' }
+        it { should be_truthy }
+      end
+
+      context 'named Gemfile' do
+        let(:path) { 'test/Gemfile' }
+        it { should be_truthy }
+      end
+
+      context 'named Gemfile in directory' do
+        let(:path) { 'test/Gemfile' }
+        it { should be_truthy }
+      end
+
       context 'executable' do
         let(:path) { 'test' }
         before { File.stub(:open).with(path).and_return(shebang) }


### PR DESCRIPTION
This allows `pronto-rubocop` (and others) to treat the common `Gemfile` and `*.gemspec` files as Ruby.