### PR TITLE
Bitbucket deprecated its API v1.0: update all endpoints to API v2.0

### DIFF
--- a/lib/pronto/clients/bitbucket_client.rb
+++ b/lib/pronto/clients/bitbucket_client.rb
@@ -21,7 +21,7 @@ class BitbucketClient
   end
 
   def pull_requests(slug)
-    response = get("#{pull_request_api(slug)}/pullrequests?state=OPEN")
+    response = get("/#{slug}/pullrequests?state=OPEN")
     openstruct(response['values'])
   end
 

--- a/lib/pronto/clients/bitbucket_client.rb
+++ b/lib/pronto/clients/bitbucket_client.rb
@@ -30,11 +30,11 @@ class BitbucketClient
   end
 
   def approve_pull_request(slug, pull_id)
-    self.class.post("#{slug}/pullrequests/#{pull_id}/approve")
+    self.class.post("/#{slug}/pullrequests/#{pull_id}/approve")
   end
 
   def unapprove_pull_request(slug, pull_id)
-    self.class.delete("#{slug}/pullrequests/#{pull_id}/approve")
+    self.class.delete("/#{slug}/pullrequests/#{pull_id}/approve")
   end
 
   private


### PR DESCRIPTION
@Mathiou04 created this pull request [#347](https://github.com/prontolabs/pronto/pull/347) but he/she forgot to update pull_requests method, so I fix it and submit this pull request.

