### PR TITLE
Add a GitHub Actions Integration section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,30 @@ formatters = [formatter, status_formatter]
 Pronto.run('origin/master', '.', formatters)
 ```
 
+#### GitHub Actions Integration
+
+You can also run Pronto as a GitHub action. 
+
+Here's an example `.github/workflows/pronto.yml` workflow file using the `github_status` and `github_pr` formatters and running on each GitHub PR, with `pronto-rubocop` as the runner:
+
+```yml
+name: Pronto
+on: [pull_request]
+
+jobs:
+  pronto:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@master
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+      - run: gem install pronto pronto-rubocop
+      - run: PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")" PRONTO_GITHUB_ACCESS_TOKEN="${{ secrets.GITHUB_TOKEN }}" pronto run -f github_status github_pr -c origin/master
+```
+
 ### GitLab Integration
 
 You can run Pronto as a step of your CI builds and get the results as comments


### PR DESCRIPTION
Adds a section describing a sample GitHub Actions workflow setup for Pronto.