### PR TITLE
fix: usr: 362: fix duplicate comments issue in bitbucket

### DIFF
--- a/lib/pronto/clients/bitbucket_client.rb
+++ b/lib/pronto/clients/bitbucket_client.rb
@@ -7,7 +7,7 @@ class BitbucketClient
   end
 
   def commit_comments(slug, sha)
-    response = get("/#{slug}/changesets/#{sha}/comments")
+    response = get_all_comments("/#{slug}/changesets/#{sha}/comments")
     parse_comments(openstruct(response['values']))
   end
 
@@ -16,7 +16,7 @@ class BitbucketClient
   end
 
   def pull_comments(slug, pull_id)
-    response = get("/#{slug}/pullrequests/#{pull_id}/comments")
+    response = get_all_comments("/#{slug}/pullrequests/#{pull_id}/comments")
     parse_comments(openstruct(response['values']))
   end
 
@@ -38,6 +38,17 @@ class BitbucketClient
   end
 
   private
+
+  def get_all_comments(url)
+    all_comments = []
+    comments = get(url)
+    all_comments = all_comments + comments['values']
+    if comments['next']
+      get_all_comments(comments['next'])
+    else
+      all_comments
+    end
+  end
 
   def openstruct(response)
     response.map { |r| OpenStruct.new(r) }

--- a/lib/pronto/clients/bitbucket_client.rb
+++ b/lib/pronto/clients/bitbucket_client.rb
@@ -8,7 +8,7 @@ class BitbucketClient
 
   def commit_comments(slug, sha)
     response = get_all_comments("/#{slug}/changesets/#{sha}/comments?pagelen=100")
-    parse_comments(openstruct(response['values']))
+    parse_comments(openstruct(response))
   end
 
   def create_commit_comment(slug, sha, body, path, position)
@@ -17,7 +17,7 @@ class BitbucketClient
 
   def pull_comments(slug, pull_id)
     response = get_all_comments("/#{slug}/pullrequests/#{pull_id}/comments?pagelen=100")
-    parse_comments(openstruct(response['values']))
+    parse_comments(openstruct(response))
   end
 
   def pull_requests(slug)

--- a/lib/pronto/clients/bitbucket_client.rb
+++ b/lib/pronto/clients/bitbucket_client.rb
@@ -7,7 +7,7 @@ class BitbucketClient
   end
 
   def commit_comments(slug, sha)
-    response = get_all_comments("/#{slug}/changesets/#{sha}/comments")
+    response = get_all_comments("/#{slug}/changesets/#{sha}/comments?pagelen=100")
     parse_comments(openstruct(response['values']))
   end
 
@@ -16,7 +16,7 @@ class BitbucketClient
   end
 
   def pull_comments(slug, pull_id)
-    response = get_all_comments("/#{slug}/pullrequests/#{pull_id}/comments")
+    response = get_all_comments("/#{slug}/pullrequests/#{pull_id}/comments?pagelen=100")
     parse_comments(openstruct(response['values']))
   end
 


### PR DESCRIPTION
Bitbucket v2 api fetches only 10 records and it is paginated, so its  not able to check beyond 10 comments and duplicates the comments