### PR TITLE
Use Dir.chdir() with working_dir

### DIFF
--- a/lib/pronto/cli.rb
+++ b/lib/pronto/cli.rb
@@ -61,9 +61,9 @@ module Pronto
       repo_workdir = ::Rugged::Repository.discover(path).workdir
       relative     = path.sub(repo_workdir, '')
 
-      messages = Dir.chdir(repo_workdir) do
+      messages = Dir.chdir(path) do
         file = relative.length != path.length ? relative : nil
-        ::Pronto.run(commit, '.', formatters, file)
+        ::Pronto.run(commit, repo_workdir, formatters, file)
       end
       if options[:'exit-code']
         error_messages_count = messages.count { |m| m.level != :info }


### PR DESCRIPTION
hi.
i am using https://github.com/prontolabs/pronto-rubocop.

The rubocop.yml determines the excluding path(etc...) from the working directory. Therefore, the argument of Dir.chdir must be the working directory.

Otherwise, the excluding path written as a relative path in rubocop.yml will cause a mismatch.

```shell
ex)

$ ls
.git
rails_project/.rubocop.yml
rails_project/app
rails_project/db/schema.rb
[...]

$ cat ./rails_project/.rubocop.yml
AllCops:
  Exclude:
    - 'db/schema.rb'

$ cd rails_project && pronto ...

# << Could not exclude db/schema.rb... >>
```

I am having this problem in my monorepo environment.
`::RuboCop::ConfigLoader.load_file(".rubocop.yml").for_all_cops` 👈try to make sure.

thanks.