### PR TITLE
Fix commits until walk

### DIFF
--- a/lib/pronto/git/repository.rb
+++ b/lib/pronto/git/repository.rb
@@ -38,7 +38,7 @@ module Pronto
 
       def commits_until(sha)
         result = []
-        @repo.walk(head, Rugged::SORT_TOPO).take_while do |commit|
+        @repo.walk(head_commit_sha, Rugged::SORT_TOPO).take_while do |commit|
           result << commit.oid
           !commit.oid.start_with?(sha)
         end


### PR DESCRIPTION
It seems rugged < 0.28 also accepts "Commits" objects, but starting 0.99
it will only accept SHAs for the walk. It seems to work for versions
before 0.28 as well.