### PR TITLE
Fix running pronto inside git submodules

### DIFF
--- a/lib/pronto/git/repository.rb
+++ b/lib/pronto/git/repository.rb
@@ -46,7 +46,7 @@ module Pronto
       end
 
       def path
-        Pathname.new(@repo.path).parent
+        Pathname.new(@repo.workdir).cleanpath
       end
 
       def blame(path, lineno)


### PR DESCRIPTION
`Rugged::Repository#path` returns the path for the git repository
itself. For git submodules the path is somewhere up the directory tree:

```
/root/.git/modules/submodule/ <-- Rugged::Repository#path
/root/submodule               <-- Rugged::Repository#workdir
```

Using `Rugged::Repository#workdir` fixes the issue for submodules and
also works for normal git repositories.

Fixes #76