### PR TITLE
Updating thor dependency version

### DIFF
--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('octokit', '~> 4.7', '>= 4.7.0')
   s.add_runtime_dependency('rainbow', '>= 2.2', '< 4.0')
   s.add_runtime_dependency('rugged', '>= 0.23.0', '< 1.1.0')
-  s.add_runtime_dependency('thor', '>= 0.20.3', '< 2.0')
+  s.add_runtime_dependency('thor', '~> 1', '< 2.0')
   s.add_development_dependency('bundler', '>= 1.15')
   s.add_development_dependency('pronto-rubocop', '~> 0.10.0')
   s.add_development_dependency('rake', '~> 12.0')


### PR DESCRIPTION
Upgrade thor dependency to v 1.0 minimum to fit Rails 6.1 needs.