### PR TITLE
Fix pronto on GitHub actions

### DIFF
--- a/.github/workflows/pronto-action.yml
+++ b/.github/workflows/pronto-action.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: actions/checkout@v1
       - uses: HeRoMo/pronto-action@v1.13.0
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ github.token }}

--- a/.github/workflows/pronto-action.yml
+++ b/.github/workflows/pronto-action.yml
@@ -1,0 +1,12 @@
+name: Pronto action
+on:
+  pull_request:
+    types: [opened, synchronize]
+jobs:
+  pronto:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: HeRoMo/pronto-action@v1.13.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pronto-wiki.yml
+++ b/.github/workflows/pronto-wiki.yml
@@ -7,8 +7,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - run: |
-          git fetch --no-tags --prune --depth=10 origin +refs/heads/*:refs/remotes/origin/*
+        with:
+          fetch-depth: 0
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/pronto-wiki.yml
+++ b/.github/workflows/pronto-wiki.yml
@@ -1,0 +1,17 @@
+name: Pronto
+on: [pull_request]
+
+jobs:
+  pronto:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - run: |
+          git fetch --no-tags --prune --depth=10 origin +refs/heads/*:refs/remotes/origin/*
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+      - name: Setup pronto
+        run: gem install pronto pronto-rubocop
+      - name: Run Pronto
+        run: PRONTO_PULL_REQUEST_ID="$(jq --raw-output .number "$GITHUB_EVENT_PATH")" PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" pronto run -f github_status github_pr -c origin/${{ github.base_ref }}

--- a/.github/workflows/pronto-wiki.yml
+++ b/.github/workflows/pronto-wiki.yml
@@ -1,4 +1,4 @@
-name: Pronto
+name: Pronto wiki
 on: [pull_request]
 
 jobs:
@@ -11,6 +11,8 @@ jobs:
           git fetch --no-tags --prune --depth=10 origin +refs/heads/*:refs/remotes/origin/*
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5
       - name: Setup pronto
         run: gem install pronto pronto-rubocop
       - name: Run Pronto

--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -1,0 +1,43 @@
+name: Pronto
+
+on:
+  pull_request_target:
+
+jobs:
+  pronto:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5
+          bundler-cache: true
+      - name: Cache gems
+        id: cache-gems
+        uses: actions/cache@v2
+        with:
+          path: gem_cache
+          key: ${{ runner.os }}-2.5-gems-${{ hashFiles('pronto.gemspec') }}
+      - name: Install pronto
+        env:
+          GEM_HOME: gem_cache
+          GEM_PATH: gem_cache
+        run: |
+          gem install bundler
+          bundle install --system
+          gem build pronto.gemspec
+          gem install pronto-*.gem
+      - name: Run pronto
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GEM_HOME: gem_cache
+          GEM_PATH: gem_cache
+        run: |
+          export PATH=$(pwd)/gem_cache/bin:$PATH
+          hub pr checkout ${{ github.event.pull_request.number }}
+          PRONTO_PULL_REQUEST_ID=${{ github.event.pull_request.number }} \
+          PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" \
+            pronto run -r rubocop -f github_status github_pr -c origin/${{ github.event.pull_request.base.ref }}

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -34,10 +34,3 @@ jobs:
           COVERAGE: true
         with:
           coverageCommand: bundle exec rspec
-      - if: matrix.ruby-version == '2.4' && github.event_name == 'pull_request'
-        name: Run pronto
-        run: |
-          git fetch -q origin ${{ github.context.pull_request.base.sha }}
-          PRONTO_PULL_REQUEST_ID=${{github.event.number}} \
-          PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" \
-            bundle exec pronto run -f github_status github_pr -c origin/${{ github.event.pull_request.base.ref }}

--- a/lib/pronto/client.rb
+++ b/lib/pronto/client.rb
@@ -10,6 +10,8 @@ module Pronto
     def env_pull_id
       if (pull_request = ENV['PULL_REQUEST_ID'])
         warn "[DEPRECATION] `PULL_REQUEST_ID` is deprecated.  Please use `PRONTO_PULL_REQUEST_ID` instead."
+
+
       end
 
       pull_request ||= ENV['PRONTO_PULL_REQUEST_ID']

--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('rugged', '>= 0.23.0', '< 1.1.0')
   s.add_runtime_dependency('thor', '>= 0.20.3', '< 2.0')
   s.add_development_dependency('bundler', '>= 1.15')
-  s.add_development_dependency('pronto-rubocop', '~> 0.10.0')
+  s.add_development_dependency('pronto-rubocop', '~> 0.11.1')
   s.add_development_dependency('rake', '~> 12.0')
   s.add_development_dependency('rspec', '~> 3.4')
   s.add_development_dependency('rspec-its', '~> 1.2')


### PR DESCRIPTION
When the specs action is triggered by `pull_request` Pronto can not
post reports to GitHub because there isn't a token present (the action
only has read access to the repository).

Since the `pull_request_target` action has write access to the repository
we must make sure that no code that is coming from the PR is executed.
The workflow definition used for those actions are always taken from the
target branch which means the pull request can not modify what is run.

The `pronto` workflow is a mouth full for a couple of reasons:

* Since we can not use `bundle exec` (it would execute code from the
  pull request) we must install all dependencies and pronto itself as
  system gems.
* `bundle install --system` does not install pronto itself, we must
  build and install it from the `gemspec`
* Installing `rugged` takes a while, to be able to cache the system gems
  we have to use a custom `GEM_HOME`
* `pronto-rubocop` needs a newer version because `0.10.0` is not
  compatible with pronto `0.11` (this wasn't an issue before because
  bundle install does not verify the version of the gem it is run in)
* After all gems are installed we are checking out the pull requests
  code and finally run pronto
* pronto has to run on Ruby 2.5 because version `4.14.0` is marked as
  compatible with ruby 2.4 but [breaks with a runtime error][1]
* Explicitly setting the pronto runners makes sure the workflow does not
  silently succeed if - for some reason - pronto-rubocop was not
  installed properly or could not be loaded by pronto

[1]: https://github.com/NARKOZ/gitlab/issues/550