### PR TITLE
Add `--workdir` option

### DIFF
--- a/lib/pronto/cli.rb
+++ b/lib/pronto/cli.rb
@@ -33,6 +33,11 @@ module Pronto
                   type: :boolean,
                   desc: 'Analyze changes in git staging area'
 
+    method_option :workdir,
+                  type: :boolean,
+                  aliases: ['-w'],
+                  desc: 'Analyze both staged and unstaged changes'
+
     method_option :runner,
                   type: :array,
                   default: [],
@@ -55,7 +60,7 @@ module Pronto
 
       formatters = ::Pronto::Formatter.get(options[:formatters])
 
-      commit_options = %i[staged unstaged index]
+      commit_options = %i[workdir staged unstaged index]
       commit = commit_options.find { |o| options[o] } || options[:commit]
 
       repo_workdir = ::Rugged::Repository.discover(path).workdir

--- a/lib/pronto/git/repository.rb
+++ b/lib/pronto/git/repository.rb
@@ -13,6 +13,18 @@ module Pronto
                             [head_commit_sha, @repo.index.diff(options)]
                           when :staged
                             [head_commit_sha, head.diff(@repo.index, options)]
+                          when :workdir
+                            [
+                              head_commit_sha,
+                              @repo.diff_workdir(
+                                head,
+                                {
+                                  include_untracked: true,
+                                  include_untracked_content: true,
+                                  recurse_untracked_dirs: true
+                                }.merge(options || {})
+                              )
+                            ]
                           else
                             merge_base = merge_base(commit)
                             patches = @repo.diff(merge_base, head, options)

--- a/spec/pronto/git/repository_spec.rb
+++ b/spec/pronto/git/repository_spec.rb
@@ -92,6 +92,15 @@ module Pronto
           let(:sha) { :staged }
           it { should be_one }
         end
+
+        context 'workdir' do
+          let(:sha) { :workdir }
+
+          it do
+            # this count includes all the files from the repositories (*.git)
+            subject.count.should eq 48
+          end
+        end
       end
 
       describe '#blame' do


### PR DESCRIPTION
Allows for both staged and unstaged files to be checked.

This is a stab at a solution for #263. I'm new to both Pronto and Rugged, so hopefully this isn't too far off base.