### PR TITLE
 Run pronto on GitHub Actions without any reporting 

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -1,0 +1,20 @@
+name: Pronto
+
+on:
+  pull_request:
+    branches: [master]
+
+jobs:
+  pronto:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5
+          bundler-cache: true
+      - name: Run Pronto
+        run: bundle exec pronto run --exit-code -c origin/${{ github.base_ref }}

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -22,6 +22,9 @@ jobs:
           - ruby-version: "2.3" # Rugged uses the wrong openssl version on CI and segfaults (similar to https://github.com/libgit2/rugged/issues/718)
     steps:
       - uses: actions/checkout@v2
+      - name: Use specific gitlab gem version (if required)
+        if: matrix.ruby-version == '2.4'
+        run: echo "gem 'gitlab', '< 4.14.1'" >> Gemfile.local
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -34,10 +34,3 @@ jobs:
           COVERAGE: true
         with:
           coverageCommand: bundle exec rspec
-      - if: matrix.ruby-version == '2.4' && github.event_name == 'pull_request'
-        name: Run pronto
-        run: |
-          git fetch -q origin ${{ github.context.pull_request.base.sha }}
-          PRONTO_PULL_REQUEST_ID=${{github.event.number}} \
-          PRONTO_GITHUB_ACCESS_TOKEN="${{ github.token }}" \
-            bundle exec pronto run -f github_status github_pr -c origin/${{ github.event.pull_request.base.ref }}

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,6 @@
 source 'https://rubygems.org'
 
 gemspec
+
+local_gemfile = File.expand_path('Gemfile.local', __dir__)
+eval_gemfile local_gemfile if File.exist?(local_gemfile)


### PR DESCRIPTION
In #401 we discussed that there
currently is no 100% safe way to run pronto on `pull_request_target`
actions we can not send any reports to the GitHub pull request.

This simple action will show up as a failed check. The offences then
need to be viewed in the action output.