### PR TITLE
Fix the case when a file from diff does not exist in a container.

### DIFF
--- a/lib/pronto/runner.rb
+++ b/lib/pronto/runner.rb
@@ -53,7 +53,7 @@ module Pronto
     end
 
     def ruby_executable?(path)
-      return false if File.directory?(path)
+      return false unless File.file?(path)
       line = File.open(path, &:readline)
       line =~ /#!.*ruby/
     rescue ArgumentError, EOFError


### PR DESCRIPTION
When a file from diff does not present in a container pronto crashes with "No such file or directory @ rb_sysopen".
This is well described in https://github.com/prontolabs/pronto/issues/338
