### PR TITLE
use rexml => 3.2.5 due to CVE-2021-28965

### DIFF
--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -44,7 +44,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('httparty', '>= 0.13.7')
   s.add_runtime_dependency('octokit', '~> 4.7', '>= 4.7.0')
   s.add_runtime_dependency('rainbow', '>= 2.2', '< 4.0')
-  s.add_runtime_dependency('rexml', '~> 3.2')
+  s.add_runtime_dependency('rexml', '~> 3.2', '>= 3.2.5')
   s.add_runtime_dependency('rugged', '>= 0.23.0', '< 1.1.0')
   s.add_runtime_dependency('thor', '>= 0.20.3', '< 2.0')
   s.add_development_dependency('bundler', '>= 1.15')


### PR DESCRIPTION
https://github.com/advisories/GHSA-8cr8-4vfw-mr7h

> The REXML gem before 3.2.5 in Ruby before 2.6.7, 2.7.x before 2.7.3, and 3.x before 3.0.1 does not properly address XML round-trip issues. An incorrect document can be produced after parsing and serializing.