### PR TITLE
Allow the default commit to run against to be configured

### DIFF
--- a/lib/pronto.rb
+++ b/lib/pronto.rb
@@ -55,9 +55,9 @@ require 'pronto/formatter/null_formatter'
 require 'pronto/formatter/formatter'
 
 module Pronto
-  def self.run(commit = 'master', repo_path = '.',
+  def self.run(commit = nil, repo_path = '.',
                formatters = [Formatter::TextFormatter.new], file = nil)
-    commit ||= 'master'
+    commit ||= default_commit
 
     repo = Git::Repository.new(repo_path)
     options = { paths: [file] } if file
@@ -71,5 +71,9 @@ module Pronto
     end
 
     result
+  end
+
+  def self.default_commit
+    Config.new.default_commit
   end
 end

--- a/lib/pronto/cli.rb
+++ b/lib/pronto/cli.rb
@@ -20,7 +20,6 @@ module Pronto
 
     method_option :commit,
                   type: :string,
-                  default: 'master',
                   aliases: '-c',
                   desc: 'Commit for the diff'
 

--- a/lib/pronto/config.rb
+++ b/lib/pronto/config.rb
@@ -11,6 +11,13 @@ module Pronto
       end
     end
 
+    def default_commit
+      default_commit =
+        ENV['PRONTO_DEFAULT_COMMIT'] ||
+        @config_hash.fetch('default_commit', 'master')
+      default_commit
+    end
+
     def consolidate_comments?
       consolidated =
         ENV['PRONTO_CONSOLIDATE_COMMENTS'] ||

--- a/lib/pronto/config_file.rb
+++ b/lib/pronto/config_file.rb
@@ -31,6 +31,7 @@ module Pronto
       'text' => {
         'format' => '%{color_location} %{color_level}: %{msg}'
       },
+      'default_commit' => 'master',
       'runners' => [],
       'formatters' => [],
       'max_warnings' => nil,

--- a/spec/pronto/config_spec.rb
+++ b/spec/pronto/config_spec.rb
@@ -3,6 +3,24 @@ module Pronto
     let(:config) { described_class.new(config_hash) }
     let(:config_hash) { {} }
 
+    describe '#default_commit' do
+      subject { config.default_commit }
+
+      context 'from env variable' do
+        before { stub_const('ENV', 'PRONTO_DEFAULT_COMMIT' => 'development') }
+        it { should == 'development' }
+      end
+
+      context 'from config hash' do
+        let(:config_hash) { { 'default_commit' => 'development' } }
+        it { should == 'development' }
+      end
+
+      context 'from default value' do
+        it { should == 'master' }
+      end
+    end
+
     describe '#github_slug' do
       subject { config.github_slug }
 


### PR DESCRIPTION
## Use Case

For repositories whose mainline branch is not `master` (new Github projects now default to `main`, and some projects require pull requests against `development` or similar), allow the default target branch for pronto to be configured. If not configured, it remains `master`.

## Notes

Similar to other congiruations, it can be specified in `.pronto.yml` (using `default_commit`) or by environment variable (`PRONTO_DEFAULT_COMMIT`).

The `-c` flag is still supported to specify a target commit. Nevertheless, configuring a default makes sense when the existing default `master` does not even exist in a project as is the case for many new Github repos.

Issue: https://github.com/prontolabs/pronto/issues/412