### PR TITLE
Remove deprecated runner on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,6 @@ Currently available:
 * [pronto-bigfiles](https://github.com/apiology/pronto-bigfiles)
 * [pronto-blacklist](https://github.com/pbstriker38/pronto-blacklist)
 * [pronto-brakeman](https://github.com/prontolabs/pronto-brakeman)
-* [pronto-bundler_audit](https://github.com/pdobb/pronto-bundler_audit)
 * [pronto-checkstyle](https://github.com/seikichi/pronto-checkstyle)
 * [pronto-coffeelint](https://github.com/siebertm/pronto-coffeelint)
 * [pronto-clang_format](https://github.com/micjabbour/pronto-clang_format)


### PR DESCRIPTION
Removed `pronto-bundler_audit` from runners list on Readme. It is a deprecated runner (as said here: https://github.com/pdobb/pronto-bundler_audit#maintainer-needed) that isn't working.