### PR TITLE
fix(Gitlab): slug_regex when url has different host

### DIFF
--- a/lib/pronto/gitlab.rb
+++ b/lib/pronto/gitlab.rb
@@ -87,8 +87,10 @@ module Pronto
     def slug_regex(url)
       if url =~ %r{^ssh:\/\/}
         %r{.*#{host}(:[0-9]+)?(:|\/)(?<slug>.*).git}
-      else
+      elsif url =~ /#{host}/
         %r{.*#{host}(:|\/)(?<slug>.*).git}
+      else
+        %r{\/\/.*?(\/)(?<slug>.*).git}
       end
     end
 

--- a/spec/pronto/gitlab_spec.rb
+++ b/spec/pronto/gitlab_spec.rb
@@ -29,6 +29,26 @@ module Pronto
           subject.should eql('prontolabs/pronto')
         end
       end
+
+      context 'http remote url' do
+        let(:repo) do
+          double(remote_urls: ['https://gitlab.example.com/prontolabs/pronto.git'])
+        end
+
+        it 'returns correct slug' do
+          subject.should eql('prontolabs/pronto')
+        end
+      end
+
+      context 'http remote url with different host' do
+        let(:repo) do
+          double(remote_urls: ['https://gitlab.example.net/prontolabs/pronto.git'])
+        end
+
+        it 'returns correct slug' do
+          subject.should eql('prontolabs/pronto')
+        end
+      end
     end
 
     describe '#commit_comments' do


### PR DESCRIPTION
Sometimes the host of runner in Gitlab can be different of `api_endpoint`.

A example:
- `api_endpoint` is `https://gitlab.com/api/v4`
- runner host is `https://git-us-east1-d.ci-gateway.int.gprd.gitlab.net:8989/group/x/y/z.git`

the difference is in `gitlab.com` and `gitlab.net`

This PR treat when hosts are differents.