### PR TITLE
Makes message for git formatters to prevent confusion

### DIFF
--- a/lib/pronto/formatter/git_formatter.rb
+++ b/lib/pronto/formatter/git_formatter.rb
@@ -10,7 +10,7 @@ module Pronto
         
         approve_pull_request(comments.count, additions.count, client) if defined?(self.approve_pull_request)
 
-        "#{additions.count} Pronto messages posted to #{pretty_name}"
+        "#{additions.count} Pronto messages posted to #{pretty_name} (#{existing.count} existing)"
       end
 
       def client_module


### PR DESCRIPTION
When Developer see that there are 0 messages posted in the log, but pronto still is failed, there is no idea what's going on.

Added more insights in the message in order to prevent such confusion.