### PR TITLE
Refer to default branch as main instead of master

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -2,7 +2,7 @@ name: Pronto
 
 on:
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   pronto:

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -2,9 +2,9 @@ name: Specs
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
-    branches: [master]
+    branches: [main]
 
 jobs:
   test:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,7 @@ do so.
 
 * Check that the issue has not already been reported.
 * Check that the issue has not already been fixed in the latest code
-  (a.k.a. `master`).
+  (a.k.a. `main`).
 * Be clear, concise and precise in your description of the problem.
 * Open an issue with a descriptive title and a summary in grammatically correct,
   complete sentences.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ gem 'pronto-flay', require: false
 
 ## Usage
 
-Pronto runs the checks on a diff between the current HEAD and the provided commit-ish (default is master).
+Pronto runs the checks on a diff between the current HEAD and the provided commit-ish (default is main).
 
 ### Local Changes
 
@@ -62,13 +62,13 @@ Navigate to the repository you want to run Pronto on, and:
 ```sh
 git checkout feature/branch
 
-# Analyze diff of committed changes on current branch and master:
+# Analyze diff of committed changes on current branch and main:
 pronto run
 
 # Analyze changes in git staging area
 pronto run --staged
 
-# Analyze diff of uncommitted changes and master:
+# Analyze diff of uncommitted changes and main:
 pronto run --unstaged
 
 # Analyze *all* changes since the *initial* commit (may take some time):
@@ -101,19 +101,19 @@ Set the PRONTO_GITHUB_ACCESS_TOKEN environment variable or value in `.pronto.yml
 Then just run it:
 
 ```sh
-$ PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github -c origin/master
+$ PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github -c origin/main
 ```
 
 If you want comments to appear on pull request diff, instead of commit:
 
 ```sh
-$ PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github_pr -c origin/master
+$ PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github_pr -c origin/main
 ```
 
 If you want review to appear on pull request diff, instead of separate comments:
 
 ```sh
-$ PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github_pr_review -c origin/master
+$ PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github_pr_review -c origin/main
 ```
 
 All the **N** pending comments will be now separated into **X** number of PR reviews.
@@ -129,26 +129,26 @@ Note: In case no environment variable or config setting is specified in `.pronto
       a default value of `30` will be used.
 
 ```sh
-$ PRONTO_WARNINGS_PER_REVIEW=30 PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github_pr_review -c origin/master
+$ PRONTO_WARNINGS_PER_REVIEW=30 PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github_pr_review -c origin/main
 ```
 
 Use `GithubStatusFormatter` to submit [commit status](https://github.com/blog/1227-commit-status-api):
 
 ```sh
-$ PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github_status -c origin/master
+$ PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github_status -c origin/main
 ```
 
 If you want to show a one single status for all runners, instead of status per runner:
 
 ```sh
-$ PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github_combined_status -c origin/master
+$ PRONTO_GITHUB_ACCESS_TOKEN=token pronto run -f github_combined_status -c origin/main
 ```
 
 It's possible to combine multiple formatters.
 To get both pull request comments and commit status summary use:
 
 ```sh
-$ PRONTO_GITHUB_ACCESS_TOKEN=token PRONTO_PULL_REQUEST_ID=id pronto run -f github_status github_pr -c origin/master
+$ PRONTO_GITHUB_ACCESS_TOKEN=token PRONTO_PULL_REQUEST_ID=id pronto run -f github_status github_pr -c origin/main
 ```
 
 As an alternative, you can also set up a rake task:
@@ -159,7 +159,7 @@ Pronto::GemNames.new.to_a.each { |gem_name| require "pronto/#{gem_name}" }
 formatter = Pronto::Formatter::GithubFormatter.new # also possible: GithubPullRequestFormatter, GithubPullRequestReviewFormatter
 status_formatter = Pronto::Formatter::GithubStatusFormatter.new
 formatters = [formatter, status_formatter]
-Pronto.run('origin/master', '.', formatters)
+Pronto.run('origin/main', '.', formatters)
 ```
 
 #### GitHub Actions Integration
@@ -211,7 +211,7 @@ to your Gitlab private token which you can find in your account settings.
 Then just run it:
 
 ```sh
-$ PRONTO_GITLAB_API_PRIVATE_TOKEN=token pronto run -f gitlab -c origin/master
+$ PRONTO_GITLAB_API_PRIVATE_TOKEN=token pronto run -f gitlab -c origin/main
 ```
 
 **note: this requires at least Gitlab 11.6+**
@@ -219,7 +219,7 @@ $ PRONTO_GITLAB_API_PRIVATE_TOKEN=token pronto run -f gitlab -c origin/master
 Merge request integration:
 
 ```sh
-$ PRONTO_GITLAB_API_PRIVATE_TOKEN=token PRONTO_PULL_REQUEST_ID=id pronto run -f gitlab_mr -c origin/master
+$ PRONTO_GITLAB_API_PRIVATE_TOKEN=token PRONTO_PULL_REQUEST_ID=id pronto run -f gitlab_mr -c origin/main
 ```
 
 On GitLabCI, make sure to run Pronto in a [merge request pipeline](https://docs.gitlab.com/ce/ci/merge_request_pipelines/):
@@ -249,13 +249,13 @@ Set the PRONTO_BITBUCKET_USERNAME and PRONTO_BITBUCKET_PASSWORD environment vari
 Then just run it:
 
 ```sh
-$ PRONTO_BITBUCKET_USERNAME=user PRONTO_BITBUCKET_PASSWORD=pass pronto run -f bitbucket -c origin/master
+$ PRONTO_BITBUCKET_USERNAME=user PRONTO_BITBUCKET_PASSWORD=pass pronto run -f bitbucket -c origin/main
 ```
 
 or, if you want comments to appear on pull request diff, instead of commit:
 
 ```sh
-$ PRONTO_BITBUCKET_USERNAME=user PRONTO_BITBUCKET_PASSWORD=pass pronto run -f bitbucket_pr -c origin/master
+$ PRONTO_BITBUCKET_USERNAME=user PRONTO_BITBUCKET_PASSWORD=pass pronto run -f bitbucket_pr -c origin/main
 ```
 
 ## Configuration

--- a/lib/pronto/config.rb
+++ b/lib/pronto/config.rb
@@ -14,7 +14,7 @@ module Pronto
     def default_commit
       default_commit =
         ENV['PRONTO_DEFAULT_COMMIT'] ||
-        @config_hash.fetch('default_commit', 'master')
+        @config_hash.fetch('default_commit', 'main')
       default_commit
     end
 

--- a/lib/pronto/config_file.rb
+++ b/lib/pronto/config_file.rb
@@ -31,7 +31,7 @@ module Pronto
       'text' => {
         'format' => '%{color_location} %{color_level}: %{msg}'
       },
-      'default_commit' => 'master',
+      'default_commit' => 'main',
       'runners' => [],
       'formatters' => [],
       'max_warnings' => nil,

--- a/spec/fixtures/renamed-file.git/logs/HEAD
+++ b/spec/fixtures/renamed-file.git/logs/HEAD
@@ -1,4 +1,4 @@
 0000000000000000000000000000000000000000 81d7ad66f39011d0eedaa70e33bae27b67c3c519 Alessio Signorini <asignorini@evidation.com> 1546113502 +0000	commit (initial): first commit
-81d7ad66f39011d0eedaa70e33bae27b67c3c519 81d7ad66f39011d0eedaa70e33bae27b67c3c519 Alessio Signorini <asignorini@evidation.com> 1546113610 +0000	checkout: moving from master to new_branch
+81d7ad66f39011d0eedaa70e33bae27b67c3c519 81d7ad66f39011d0eedaa70e33bae27b67c3c519 Alessio Signorini <asignorini@evidation.com> 1546113610 +0000	checkout: moving from main to new_branch
 81d7ad66f39011d0eedaa70e33bae27b67c3c519 3e2cbd49d2d9d33b6c9eea4371eb67c947920f71 Alessio Signorini <asignorini@evidation.com> 1546113694 +0000	commit: added second file with no errors
 3e2cbd49d2d9d33b6c9eea4371eb67c947920f71 93657bccfddbce46b58c23960fea84103d90d37d Alessio Signorini <asignorini@evidation.com> 1546113701 +0000	commit: renamed original-file

--- a/spec/fixtures/test.git/HEAD
+++ b/spec/fixtures/test.git/HEAD
@@ -1,1 +1,1 @@
-ref: refs/heads/master
+ref: refs/heads/main

--- a/spec/pronto/config_spec.rb
+++ b/spec/pronto/config_spec.rb
@@ -17,7 +17,7 @@ module Pronto
       end
 
       context 'from default value' do
-        it { should == 'master' }
+        it { should == 'main' }
       end
     end
 

--- a/spec/pronto/git/repository_spec.rb
+++ b/spec/pronto/git/repository_spec.rb
@@ -10,7 +10,7 @@ module Pronto
 
       describe '#branch' do
         subject { repo.branch }
-        it { should == 'master' }
+        it { should == 'main' }
       end
 
       describe '#remote_urls' do

--- a/spec/pronto_spec.rb
+++ b/spec/pronto_spec.rb
@@ -11,8 +11,8 @@ module Pronto
         it { should be_empty }
       end
 
-      context 'master' do
-        let(:commit) { 'master' }
+      context 'main' do
+        let(:commit) { 'main' }
         it { should be_empty }
       end
 


### PR DESCRIPTION
because: GitHub has changed the default branch name to main instead of
master. This change has been replicated by many companies, organizations
and projects.

The naming change follows along the lines of an industry trend to deprecate
the usage of terms such as master and slave in favor of more inclusive
language.

More details can be found here from GitHub:

https://github.com/github/renaming

Some additional details can be found here about why GitHub and others
are doing this:

https://www.theserverside.com/feature/Why-GitHub-renamed-its-master-branch-to-main

this commit: Changes all references to the master branch to main.

I would additionally suggest renaming of the default branch on this project to main on this project. 