### PR TITLE
Relax octokit version dependency

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.5
+          ruby-version: 2.7
           bundler-cache: true
       - name: Run Pronto
         run: bundle exec pronto run --exit-code -c origin/${{ github.base_ref }}

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -12,10 +12,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - "2.3"
-          - "2.4"
-          - "2.5"
-          - "2.6"
           - "2.7"
           - "3.0"
           - "3.1"

--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   EOF
 
   s.licenses = ['MIT']
-  s.required_ruby_version = '>= 2.3.0'
+  s.required_ruby_version = '>= 2.7.0'
   s.rubygems_version = '1.8.23'
 
   s.files = `git ls-files`.split($RS).reject do |file|
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('gitlab', '~> 4.4', '>= 4.4.0')
   s.add_runtime_dependency('httparty', '>= 0.13.7')
-  s.add_runtime_dependency('octokit', '~> 4.7', '>= 4.7.0')
+  s.add_runtime_dependency('octokit',  '>= 4.7.0')
   s.add_runtime_dependency('rainbow', '>= 2.2', '< 4.0')
   s.add_runtime_dependency('rexml', '~> 3.2', '>= 3.2.5')
   s.add_runtime_dependency('rugged', '>= 0.23.0', '< 2.0')


### PR DESCRIPTION
Previous constrain was limiting where Danger 9.x cannot be used together with Pronto in a project because of different octokit dependency version requirements. There was also an issue registered suggesting this - https://github.com/prontolabs/pronto/issues/430