### PR TITLE
fix: pull_sha return value when no pull request

### DIFF
--- a/lib/pronto/github.rb
+++ b/lib/pronto/github.rb
@@ -102,6 +102,8 @@ module Pronto
 
     def pull_sha
       pull[:head][:sha] if pull
+    rescue Pronto::Error
+      nil
     end
 
     def pull


### PR DESCRIPTION
`Pronto::Formatter::GithubStatusFormatter` does not work outside of pull requests (pronto run throws an error), because `Pronto::Github#create_commit_status` retrieves sha by `sha = pull_sha || status.sha`, and pull_sha either returns pull's sha (if the pull exists) or throws an error.

This PR fixes it.

Pronto::Github#pull throws error when the PR cannot be found, thus `pull[:head][:sha] if pull` makes no sense (it exists or throws)

I fix this by catching Pronto::Error and returning nil. The error is thrown when PR cannot be found in Pronto::GithubPull#pull_by_id, Pronto::GithubPull#pull_by_branch or Pronto::GithubPull#pull_by_commit.
