### PR TITLE
Support specifying the config file path in an environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,14 @@ $ PRONTO_BITBUCKET_USERNAME=user PRONTO_BITBUCKET_PASSWORD=pass pronto run -f bi
 ## Configuration
 
 The behavior of Pronto can be controlled via the `.pronto.yml` configuration
-file. It must be placed in your project directory.
+file. It can either be placed in the working directory (*) or specified using
+the environment variable `PRONTO_CONFIG_FILE`.
+
+(*) The working directory is where you run the command from, which is typically
+your project directory.
+
+If this file cannot be found, then the default configuration in
+[Pronto::ConfigFile::EMPTY](lib/pronto/config_file.rb) applies.
 
 The file has the following format:
 

--- a/lib/pronto/config_file.rb
+++ b/lib/pronto/config_file.rb
@@ -40,7 +40,9 @@ module Pronto
       'format' => DEFAULT_MESSAGE_FORMAT
     }.freeze
 
-    def initialize(path = '.pronto.yml')
+    attr_reader :path
+
+    def initialize(path = ENV.fetch('PRONTO_CONFIG_FILE', '.pronto.yml'))
       @path = path
     end
 

--- a/spec/pronto/config_file_spec.rb
+++ b/spec/pronto/config_file_spec.rb
@@ -2,6 +2,22 @@ module Pronto
   describe ConfigFile do
     let(:config_file) { described_class.new }
 
+    describe '#path' do
+      subject { config_file.path }
+
+      it { should eq '.pronto.yml' }
+
+      context 'when specified by the environment variable' do
+        let(:file_path) { '/etc/pronto-config.yml' }
+
+        before do
+          stub_const('ENV', 'PRONTO_CONFIG_FILE' => file_path)
+        end
+
+        it { should eq file_path }
+      end
+    end
+
     describe '#to_h' do
       subject { config_file.to_h }
 


### PR DESCRIPTION
This is a simple solution to #226 that introduces support for the environment variable `PRONTO_CONFIG_FILE`.

There was a previous attempt at solving this issue in #228, but it's much more elaborate. This is a simpler solution because it doesn't try to add a CLI option.