### PR TITLE
Adds Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/pronto.yml
+++ b/.github/workflows/pronto.yml
@@ -8,7 +8,7 @@ jobs:
   pronto:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Set up Ruby

--- a/.github/workflows/specs.yml
+++ b/.github/workflows/specs.yml
@@ -19,10 +19,11 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+          - "3.2"
         exclude:
           - ruby-version: "2.3" # Rugged uses the wrong openssl version on CI and segfaults (similar to https://github.com/libgit2/rugged/issues/718)
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Use specific gitlab gem version (if required)
         if: matrix.ruby-version == '2.4'
         run: echo "gem 'gitlab', '< 4.14.1'" >> Gemfile.local


### PR DESCRIPTION
Also updates checkout action version.

The current published version of `pronto` is not compatible with Ruby 3.2, because of the `rugged` dependency.  Rugged only became Ruby 3.2 compliant as of version 1.4.2 or so.  If would be great to have this merged and a new gem version published.

Currently this is blocking some compatibility efforts on https://github.com/JEG2/highline , so an updated gem would definitely be appreciated.

cc: @abinoam 