### PR TITLE
Pin rugged to below 1.7

### DIFF
--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('octokit', '>= 4.7.0', '< 8.0')
   s.add_runtime_dependency('rainbow', '>= 2.2', '< 4.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')
-  s.add_runtime_dependency('rugged', '>= 0.23.0', '< 2.0')
+  s.add_runtime_dependency('rugged', '>= 0.23.0', '< 1.7')
   s.add_runtime_dependency('thor', '>= 0.20.3', '< 2.0')
   s.add_development_dependency('bundler', '>= 1.15')
   s.add_development_dependency('pronto-rubocop', '~> 0.10.0')


### PR DESCRIPTION
A bandaid until `pronto` is updated to support `rugged` 1.7

Fixes https://github.com/prontolabs/pronto/issues/447