### PR TITLE
Remove usage of deprecated position argument for GitHub comments

### DIFF
--- a/lib/pronto/formatter/github_pull_request_formatter.rb
+++ b/lib/pronto/formatter/github_pull_request_formatter.rb
@@ -13,9 +13,8 @@ module Pronto
         'GitHub'
       end
 
-      def line_number(message, patches)
-        line = patches.find_line(message.full_path, message.line.new_lineno)
-        line.position
+      def line_number(message, _)
+        message.line&.new_lineno
       end
     end
   end

--- a/lib/pronto/formatter/github_pull_request_review_formatter.rb
+++ b/lib/pronto/formatter/github_pull_request_review_formatter.rb
@@ -19,9 +19,8 @@ module Pronto
         $stderr.puts "Failed to post: #{e.message}"
       end
 
-      def line_number(message, patches)
-        line = patches.find_line(message.full_path, message.line.new_lineno)
-        line.position
+      def line_number(message, _)
+        message.line&.new_lineno
       end
     end
   end

--- a/pronto.gemspec
+++ b/pronto.gemspec
@@ -42,7 +42,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency('gitlab', '>= 4.4.0', '< 5.0')
   s.add_runtime_dependency('httparty', '>= 0.13.7', '< 1.0')
-  s.add_runtime_dependency('octokit', '>= 4.7.0', '< 8.0')
+  s.add_runtime_dependency('octokit', '>= 4.7.0', '< 9.0')
   s.add_runtime_dependency('rainbow', '>= 2.2', '< 4.0')
   s.add_runtime_dependency('rexml', '>= 3.2.5', '< 4.0')
   s.add_runtime_dependency('rugged', '>= 0.23.0', '< 2.0')

--- a/spec/pronto/formatter/github_formatter_spec.rb
+++ b/spec/pronto/formatter/github_formatter_spec.rb
@@ -42,7 +42,7 @@ module Pronto
             Octokit::Client.any_instance
               .should_receive(:commit_comments)
               .once
-              .and_return([double(body: 'crucial', path: 'path/to', position: nil)])
+              .and_return([double(body: 'crucial', path: 'path/to', line: nil)])
 
             Octokit::Client.any_instance.should_not_receive(:create_commit_comment)
 
@@ -62,7 +62,7 @@ module Pronto
             Octokit::Client.any_instance
               .should_receive(:commit_comments)
               .once
-              .and_return([double(body: 'existed', path: 'path/to', position: nil)])
+              .and_return([double(body: 'existed', path: 'path/to', line: nil)])
 
             Octokit::Client.any_instance.should_receive(:create_commit_comment).once
 

--- a/spec/pronto/formatter/github_pull_request_formatter_spec.rb
+++ b/spec/pronto/formatter/github_pull_request_formatter_spec.rb
@@ -12,26 +12,60 @@ module Pronto
         let(:patch) { repo.show_commit('64dadfd').first }
         let(:line) { patch.added_lines.first }
         let(:patches) { repo.diff('64dadfd^') }
+        let(:octokit_client) { instance_double(Octokit::Client) }
 
         before do
           ENV['PRONTO_PULL_REQUEST_ID'] = '10'
-          Octokit::Client.any_instance
-            .should_receive(:pull_requests)
+          Octokit::Client.stub(:new).and_return(octokit_client)
+          octokit_client
+            .stub(:pull_requests)
             .once
             .and_return([{ number: 10, head: { sha: 'foo' } }])
 
-          Octokit::Client.any_instance
-            .should_receive(:pull_comments)
+          octokit_client
+            .stub(:pull_comments)
             .once
-            .and_return([])
+            .and_return([double(body: 'a comment', path: 'a/path', line: 5)])
         end
 
         specify do
-          Octokit::Client.any_instance
+          octokit_client
             .should_receive(:create_pull_comment)
             .once
 
           subject
+        end
+
+        context 'with duplicate comment' do
+          let(:messages) { [message] }
+          let(:message) { Message.new('path/to', line, :warning, 'existed') }
+          let(:line) { double(new_lineno: 3, commit_sha: '123', position: 3) }
+
+          specify do
+            octokit_client.should_receive(:pull_comments).and_return(
+              [double(body: 'existed', path: 'path/to', line: line.new_lineno)]
+            )
+
+            octokit_client.should_not_receive(:create_pull_comment)
+
+            subject.should eq '0 Pronto messages posted to GitHub (1 existing)'
+          end
+        end
+
+        context 'with one duplicate and one non duplicated comment' do
+          let(:messages) { [message, existing_message] }
+          let(:message) { Message.new('path/to', line, :warning, 'crucial') }
+          let(:existing_message) { Message.new('path/to', line, :warning, 'existed') }
+
+          specify do
+            octokit_client.should_receive(:pull_comments).and_return(
+              [double(body: 'existed', path: 'path/to', line: line.new_lineno)]
+            )
+
+            octokit_client.should_receive(:create_pull_comment).once
+
+            subject.should eq '1 Pronto messages posted to GitHub (1 existing)'
+          end
         end
 
         context 'error handling' do
@@ -54,7 +88,7 @@ module Pronto
 
           it 'handles and prints details' do
             error = Octokit::UnprocessableEntity.from_response(error_response)
-            Octokit::Client.any_instance
+            octokit_client
               .should_receive(:create_pull_comment)
               .and_raise(error)
 

--- a/spec/pronto/formatter/github_pull_request_review_formatter_spec.rb
+++ b/spec/pronto/formatter/github_pull_request_review_formatter_spec.rb
@@ -12,22 +12,50 @@ module Pronto
         let(:patch) { repo.show_commit('64dadfd').first }
         let(:line) { patch.added_lines.first }
         let(:patches) { repo.diff('64dadfd^') }
+        let(:octokit_client) { instance_double(Octokit::Client) }
 
         before do
           ENV['PRONTO_PULL_REQUEST_ID'] = '10'
-
-          Octokit::Client.any_instance
-            .should_receive(:pull_comments)
-            .once
-            .and_return([])
+          Octokit::Client.stub(:new).and_return(octokit_client)
         end
 
         specify do
-          Octokit::Client.any_instance
-            .should_receive(:create_pull_request_review)
-            .once
+          octokit_client.should_receive(:pull_comments).and_return([])
+          octokit_client.should_receive(:create_pull_request_review).once
 
           subject
+        end
+
+        context 'with duplicate comment' do
+          let(:messages) { [message] }
+          let(:message) { Message.new('path/to', line, :warning, 'existed') }
+          let(:line) { double(new_lineno: 3, commit_sha: '123', position: 3) }
+
+          specify do
+            octokit_client.should_receive(:pull_comments).and_return(
+              [double(body: 'existed', path: 'path/to', line: line.new_lineno)]
+            )
+
+            octokit_client.should_not_receive(:create_pull_request_review)
+
+            subject.should eq '0 Pronto messages posted to GitHub (1 existing)'
+          end
+        end
+
+        context 'with one duplicate and one non duplicated comment' do
+          let(:messages) { [message, existing_message] }
+          let(:message) { Message.new('path/to', line, :warning, 'crucial') }
+          let(:existing_message) { Message.new('path/to', line, :warning, 'existed') }
+
+          specify do
+            octokit_client.should_receive(:pull_comments).and_return(
+              [double(body: 'existed', path: 'path/to', line: line.new_lineno)]
+            )
+
+            octokit_client.should_receive(:create_pull_request_review).once
+
+            subject.should eq '1 Pronto messages posted to GitHub (1 existing)'
+          end
         end
       end
     end

--- a/spec/pronto/github_spec.rb
+++ b/spec/pronto/github_spec.rb
@@ -8,8 +8,7 @@ module Pronto
     let(:comment) { double(body: 'note', path: 'path', line: 1, position: 1) }
     let(:empty_client_options) do
       {
-        event: 'COMMENT',
-        accept: 'application/vnd.github.v3.diff+json'
+        event: 'COMMENT'
       }
     end
 
@@ -157,8 +156,8 @@ module Pronto
         end
         let(:options) do
           empty_client_options
-            .merge(comments: [{ path: 'bad_file.rb', position: 10, body: 'Offense #1' },
-                              { path: 'bad_file.rb', position: 20, body: 'Offense #2' }])
+            .merge(comments: [{ path: 'bad_file.rb', line: 10, body: 'Offense #1' },
+                              { path: 'bad_file.rb', line: 20, body: 'Offense #2' }])
         end
 
         {
@@ -184,11 +183,11 @@ module Pronto
           let(:warnings_per_review) { 1 }
           let(:first_options) do
             empty_client_options
-              .merge(comments: [{ path: 'bad_file.rb', position: 10, body: 'Offense #1' }])
+              .merge(comments: [{ path: 'bad_file.rb', line: 10, body: 'Offense #1' }])
           end
           let(:second_options) do
             empty_client_options
-              .merge(comments: [{ path: 'bad_file.rb', position: 20, body: 'Offense #2' }])
+              .merge(comments: [{ path: 'bad_file.rb', line: 20, body: 'Offense #2' }])
           end
 
           specify do


### PR DESCRIPTION
- This allows usage of Octokit v8.0.0

Fixes: #453 