### PR TITLE
GitHub - Feature delete outdated comments

### DIFF
--- a/lib/pronto/comment.rb
+++ b/lib/pronto/comment.rb
@@ -1,5 +1,5 @@
 module Pronto
-  Comment = Struct.new(:sha, :body, :path, :position) do
+  Comment = Struct.new(:sha, :body, :path, :position, :id) do
     def ==(other)
       position == other.position &&
         path == other.path &&

--- a/lib/pronto/formatter/git_formatter.rb
+++ b/lib/pronto/formatter/git_formatter.rb
@@ -6,8 +6,10 @@ module Pronto
         existing = existing_comments(messages, client, repo)
         comments = new_comments(messages, patches)
         additions = remove_duplicate_comments(existing, comments)
+        outdated_comments = existing.reject { |key, _| comments.key?(key) }.values.flatten
+        remove_outdated_comments(client, outdated_comments) if respond_to?(:remove_outdated_comments)
         submit_comments(client, additions)
-        
+
         approve_pull_request(comments.count, additions.count, client) if defined?(self.approve_pull_request)
 
         "#{additions.count} Pronto messages posted to #{pretty_name} (#{existing.count} existing)"

--- a/lib/pronto/formatter/github_pull_request_formatter.rb
+++ b/lib/pronto/formatter/github_pull_request_formatter.rb
@@ -16,6 +16,14 @@ module Pronto
       def line_number(message, _)
         message.line&.new_lineno
       end
+
+      def remove_outdated_comments(client, outdated_comments)
+        outdated_comments.each do |comment|
+          client.delete_comment(comment)
+        end
+      rescue Octokit::UnprocessableEntity, HTTParty::Error => e
+        warn "Failed to delete: #{e.message}"
+      end
     end
   end
 end

--- a/lib/pronto/github.rb
+++ b/lib/pronto/github.rb
@@ -11,7 +11,7 @@ module Pronto
       @comment_cache["#{pull_id}/#{sha}"] ||= begin
         client.pull_comments(slug, pull_id).map do |comment|
           Comment.new(
-            sha, comment.body, comment.path, comment.line || comment.original_line
+            sha, comment.body, comment.path, comment.line || comment.original_line, comment.id
           )
         end
       end
@@ -64,6 +64,10 @@ module Pronto
       client.create_status(slug, sha, status.state,
                            context: status.context,
                            description: status.description)
+    end
+
+    def delete_comment(comment)
+      client.delete_pull_comment(slug, comment.id)
     end
 
     private

--- a/spec/pronto/formatter/github_pull_request_formatter_spec.rb
+++ b/spec/pronto/formatter/github_pull_request_formatter_spec.rb
@@ -25,13 +25,15 @@ module Pronto
           octokit_client
             .stub(:pull_comments)
             .once
-            .and_return([double(body: 'a comment', path: 'a/path', line: 5)])
+            .and_return([double(body: 'a comment', path: 'a/path', line: 5, id: 1_881_471_822)])
         end
 
         specify do
           octokit_client
             .should_receive(:create_pull_comment)
             .once
+
+          octokit_client.should_receive(:delete_pull_comment).with(nil, 1_881_471_822).and_return(true)
 
           subject
         end
@@ -43,7 +45,7 @@ module Pronto
 
           specify do
             octokit_client.should_receive(:pull_comments).and_return(
-              [double(body: 'existed', path: 'path/to', line: line.new_lineno)]
+              [double(body: 'existed', path: 'path/to', line: line.new_lineno, id: 1_881_471_822)]
             )
 
             octokit_client.should_not_receive(:create_pull_comment)
@@ -59,7 +61,7 @@ module Pronto
 
           specify do
             octokit_client.should_receive(:pull_comments).and_return(
-              [double(body: 'existed', path: 'path/to', line: line.new_lineno)]
+              [double(body: 'existed', path: 'path/to', line: line.new_lineno, id: 1_881_471_822)]
             )
 
             octokit_client.should_receive(:create_pull_comment).once
@@ -91,6 +93,8 @@ module Pronto
             octokit_client
               .should_receive(:create_pull_comment)
               .and_raise(error)
+
+            octokit_client.should_receive(:delete_pull_comment).with(nil, 1_881_471_822).and_return(true)
 
             $stderr.should_receive(:puts) do |line|
               line.should =~ /Failed to post/

--- a/spec/pronto/formatter/github_pull_request_review_formatter_spec.rb
+++ b/spec/pronto/formatter/github_pull_request_review_formatter_spec.rb
@@ -33,7 +33,7 @@ module Pronto
 
           specify do
             octokit_client.should_receive(:pull_comments).and_return(
-              [double(body: 'existed', path: 'path/to', line: line.new_lineno)]
+              [double(body: 'existed', path: 'path/to', line: line.new_lineno, id: 1_881_471_822)]
             )
 
             octokit_client.should_not_receive(:create_pull_request_review)
@@ -49,7 +49,7 @@ module Pronto
 
           specify do
             octokit_client.should_receive(:pull_comments).and_return(
-              [double(body: 'existed', path: 'path/to', line: line.new_lineno)]
+              [double(body: 'existed', path: 'path/to', line: line.new_lineno, id: 1_881_471_822)]
             )
 
             octokit_client.should_receive(:create_pull_request_review).once

--- a/spec/pronto/github_spec.rb
+++ b/spec/pronto/github_spec.rb
@@ -5,7 +5,7 @@ module Pronto
     let(:ssh_remote_urls) { ["git@github.com:#{github_slug}.git"] }
     let(:github_slug) { 'prontolabs/pronto' }
     let(:sha) { '61e4bef' }
-    let(:comment) { double(body: 'note', path: 'path', line: 1, position: 1) }
+    let(:comment) { double(body: 'note', path: 'path', line: 1, position: 1, id: 1_881_471_822) }
     let(:empty_client_options) do
       {
         event: 'COMMENT'


### PR DESCRIPTION
- Remove outdated comments that were previously left on the code if the user has pushed new commits addressing those comments.
- Ensure that all resolved comments are cleared to keep the review process clean and up-to-date.