### PR TITLE
Fix uninitialized constant OpenStruct

### DIFF
--- a/lib/pronto/clients/bitbucket_client.rb
+++ b/lib/pronto/clients/bitbucket_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 
 class BitbucketClient

--- a/lib/pronto/clients/bitbucket_client.rb
+++ b/lib/pronto/clients/bitbucket_client.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 class BitbucketClient
   include HTTParty
   base_uri 'https://api.bitbucket.org/2.0/repositories'

--- a/lib/pronto/clients/bitbucket_server_client.rb
+++ b/lib/pronto/clients/bitbucket_server_client.rb
@@ -1,3 +1,5 @@
+require 'ostruct'
+
 class BitbucketServerClient
   include HTTParty
 

--- a/lib/pronto/clients/bitbucket_server_client.rb
+++ b/lib/pronto/clients/bitbucket_server_client.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'ostruct'
 
 class BitbucketServerClient


### PR DESCRIPTION
currently running pronto bitbucket_pr will result in error `uninitialized constant BitbucketClient::OpenStruct (NameError)`

the reason it's good up until now (at least in my project) was probably because there are other gems requiring ostruct, for example `rubocop`, through `pronto-rubocop`. after rubocop 1.58.0, it's no longer using ostruct so any pronto (with pronto-rubocop) should fail after upgrading to the latest rubocop.