### PR TITLE
Ensure options is always a Hash in diff to avoid Rugged errors

### DIFF
--- a/lib/pronto/git/repository.rb
+++ b/lib/pronto/git/repository.rb
@@ -8,6 +8,7 @@ module Pronto
       end
 
       def diff(commit, options = nil)
+        options ||= {}
         target, patches = case commit
                           when :unstaged, :index
                             [head_commit_sha, @repo.index.diff(options)]
@@ -22,7 +23,7 @@ module Pronto
                                   include_untracked: true,
                                   include_untracked_content: true,
                                   recurse_untracked_dirs: true
-                                }.merge(options || {})
+                                }.merge(options)
                               )
                             ]
                           else


### PR DESCRIPTION
## Description

This PR fixes an issue where `Rugged::Repository#diff` could receive `nil` as the `options` argument, causing the following error:

```ruby
undefined method `[]' for nil:NilClass (NoMethodError)
```

This happens because the `diff` method in `Pronto::Git::Repository` passes `options` directly to **Rugged** without ensuring it’s a Hash. When `options` is `nil` (the default value), **Rugged** fails.

## What changed

Initialized `options` with an empty Hash if `nil`:

```ruby
options ||= {}
```


In `:workdir` case simplified `.merge(options || {})` to `.merge(options)` since `options` is guaranteed to be a Hash.

## Why

This makes the method safer and consistent across all cases. Previously:

For `:workdir`, a merge fallback (`options || {}`) was already in place.

For other cases (`:unstaged`, `:index`, `:staged`, `else`), **Rugged** could fail when options was `nil`.

## Example

Before:
```ruby
repo.diff(commit, nil) # => NoMethodError
```


After:
```ruby
repo.diff(commit, {}) # Works as expected
```

No breaking changes. This only ensures `options` is never `nil`.

## Specs
No spec changes needed
<img width="954" height="100" alt="image" src="https://github.com/user-attachments/assets/fd6678f6-364d-41f7-9a2c-347c3aca6b71" />
